### PR TITLE
Fix unbound variable error in install-release.sh

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -179,4 +179,4 @@ if [[ ! -x "${binary_path}" ]]; then
   exit 1
 fi
 
-exec "${binary_path}" install -binary "${binary_path}" -bootstrap-only -start-daemon "${install_args[@]}"
+exec "${binary_path}" install -binary "${binary_path}" -bootstrap-only -start-daemon ${install_args[@]+"${install_args[@]}"}


### PR DESCRIPTION
## Summary
- Fix `bash: line 182: install_args[@]: unbound variable` error when running the install script with no extra arguments
- Use the standard `${arr[@]+"${arr[@]}"}` idiom to safely expand a potentially empty array under `set -u` (nounset)

## Reproduce
```bash
curl -fsSL https://raw.githubusercontent.com/kxn/codex-remote-feishu/master/install-release.sh | bash
```

The script fails at line 182 with `install_args[@]: unbound variable` because `install_args` is initialized as an empty array (line 40), and many bash versions treat `"${empty_array[@]}"` as an unbound variable reference when `set -u` is active.

## Test plan
- [ ] Run the install script with no extra arguments — should no longer error
- [ ] Run with extra arguments (`-- --install-bin-dir /tmp/test`) — should still pass them through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)