### PR TITLE
Fix macOS compatibility: symlinks, paths, and bash portability

### DIFF
--- a/internal/adapter/feishu/markdown_preview_helpers.go
+++ b/internal/adapter/feishu/markdown_preview_helpers.go
@@ -236,6 +236,9 @@ func previewAllowedRoots(values ...string) []string {
 		if err != nil {
 			continue
 		}
+		if real, err := filepath.EvalSymlinks(resolved); err == nil {
+			resolved = real
+		}
 		resolved = filepath.Clean(resolved)
 		if seen[resolved] {
 			continue

--- a/internal/app/daemon/admin_vscode_test.go
+++ b/internal/app/daemon/admin_vscode_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kxn/codex-remote-feishu/internal/app/install"
 	"github.com/kxn/codex-remote-feishu/internal/config"
 	"github.com/kxn/codex-remote-feishu/internal/core/agentproto"
 	relayruntime "github.com/kxn/codex-remote-feishu/internal/runtime"
@@ -124,7 +125,11 @@ func TestVSCodeApplyEditorSettings(t *testing.T) {
 		t.Fatalf("apply status = %d, want 200 body=%s", rec.Code, rec.Body.String())
 	}
 
-	settingsPath := filepath.Join(home, ".config", "Code", "User", "settings.json")
+	defaults, err := install.DetectPlatformDefaults()
+	if err != nil {
+		t.Fatalf("DetectPlatformDefaults: %v", err)
+	}
+	settingsPath := defaults.VSCodeSettingsPath
 	if readFileString(t, settingsPath) == "" {
 		t.Fatal("expected settings.json to be created")
 	}
@@ -209,7 +214,11 @@ func TestVSCodeDetectSupportsJSONCSettings(t *testing.T) {
 	binaryPath := filepath.Join(home, "bin", "codex-remote")
 	writeExecutableFile(t, binaryPath, "wrapper-binary")
 
-	settingsPath := filepath.Join(home, ".config", "Code", "User", "settings.json")
+	defaults, err := install.DetectPlatformDefaults()
+	if err != nil {
+		t.Fatalf("DetectPlatformDefaults: %v", err)
+	}
+	settingsPath := defaults.VSCodeSettingsPath
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(settings dir): %v", err)
 	}

--- a/internal/runtime/identity_paths_test.go
+++ b/internal/runtime/identity_paths_test.go
@@ -30,8 +30,12 @@ func TestBinaryIdentityHelpersAndPersistence(t *testing.T) {
 	if !strings.HasPrefix(identity.BuildFingerprint, "sha256:") {
 		t.Fatalf("fingerprint = %q, want sha256 prefix", identity.BuildFingerprint)
 	}
-	if identity.BinaryPath != binaryPath {
-		t.Fatalf("binary path = %q, want %q", identity.BinaryPath, binaryPath)
+	wantPath := binaryPath
+	if real, err := filepath.EvalSymlinks(binaryPath); err == nil {
+		wantPath = real
+	}
+	if identity.BinaryPath != wantPath {
+		t.Fatalf("binary path = %q, want %q", identity.BinaryPath, wantPath)
 	}
 
 	startedAt := time.Unix(1_700_000_000, 0).UTC()

--- a/scripts/check/smoke-install-release.sh
+++ b/scripts/check/smoke-install-release.sh
@@ -6,12 +6,20 @@ unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY all_proxy
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT_DIR}"
 
+install_bin_dir() {
+  local h="$1"
+  case "$(uname -s)" in
+    Darwin) printf '%s\n' "${h}/Library/Application Support/codex-remote/bin" ;;
+    *)      printf '%s\n' "${h}/.local/bin" ;;
+  esac
+}
+
 work_dir="$(mktemp -d)"
 server_pid=""
 daemon_pid=""
 cleanup() {
   if [[ -z "${daemon_pid}" && -n "${home_dir:-}" ]]; then
-    daemon_pid="$(ps -eo pid=,args= | awk -v target="${home_dir}/.local/bin/codex-remote daemon" '$0 ~ target {print $1; exit}')"
+    daemon_pid="$(ps -eo pid=,args= | awk -v target="$(install_bin_dir "${home_dir}")/codex-remote daemon" '$0 ~ target && !f {f=1; print $1}')"
   fi
   if [[ -n "${daemon_pid}" ]]; then
     kill "${daemon_pid}" 2>/dev/null || true
@@ -119,12 +127,13 @@ expected_dir="${install_root}/${version}"
 installed_version="$("${expected_dir}/codex-remote" version)"
 [[ "${installed_version}" == "${version}" ]]
 
-python3 - <<PY
-import json
+python3 - "${home_dir}" <<'PY'
+import json, sys
 from pathlib import Path
 
-config_path = Path(${home_dir@Q}) / ".config" / "codex-remote" / "config.json"
-state_path = Path(${home_dir@Q}) / ".local" / "share" / "codex-remote" / "install-state.json"
+home = sys.argv[1]
+config_path = Path(home) / ".config" / "codex-remote" / "config.json"
+state_path = Path(home) / ".local" / "share" / "codex-remote" / "install-state.json"
 config_payload = json.loads(config_path.read_text())
 state_payload = json.loads(state_path.read_text())
 
@@ -135,7 +144,7 @@ PY
 
 for _ in $(seq 1 60); do
   if curl --noproxy '*' -fsS "http://127.0.0.1:${admin_port}/api/setup/bootstrap-state" > "${work_dir}/bootstrap-state.json" 2>/dev/null; then
-    daemon_pid="$(ps -eo pid=,args= | awk -v target="${home_dir}/.local/bin/codex-remote daemon" '$0 ~ target {print $1; exit}')"
+    daemon_pid="$(ps -eo pid=,args= | awk -v target="$(install_bin_dir "${home_dir}")/codex-remote daemon" '$0 ~ target && !f {f=1; print $1}')"
     break
   fi
   sleep 0.2
@@ -145,17 +154,18 @@ done
 curl --noproxy '*' -fsS "http://127.0.0.1:${admin_port}/api/setup/bootstrap-state" > "${work_dir}/bootstrap-state.json"
 curl --noproxy '*' -fsS "http://127.0.0.1:${admin_port}/setup" > "${work_dir}/setup.html"
 
-python3 - <<PY
-import json
+python3 - "${work_dir}" "${admin_port}" "${relay_port}" <<'PY'
+import json, sys
 from pathlib import Path
 
-payload = json.loads((Path(${work_dir@Q}) / "bootstrap-state.json").read_text())
+work_dir, admin_port, relay_port = sys.argv[1], sys.argv[2], sys.argv[3]
+payload = json.loads((Path(work_dir) / "bootstrap-state.json").read_text())
 assert payload["setupRequired"] is True, payload
 assert payload["phase"] == "uninitialized", payload
-assert payload["admin"]["listenPort"] == str(${admin_port}), payload
-assert payload["relay"]["listenPort"] == str(${relay_port}), payload
+assert payload["admin"]["listenPort"] == admin_port, payload
+assert payload["relay"]["listenPort"] == relay_port, payload
 assert payload["session"]["trustedLoopback"] is True, payload
 
-html = (Path(${work_dir@Q}) / "setup.html").read_text()
+html = (Path(work_dir) / "setup.html").read_text()
 assert "Codex Remote" in html, html[:200]
 PY


### PR DESCRIPTION
## Summary
- **Production bug**: `previewAllowedRoots` didn't resolve symlinks, causing markdown link rewriting to silently fail on macOS (where `/tmp` → `/private/tmp`)
- **Test fixes**: VSCode admin tests hardcoded Linux paths; identity test didn't account for `EvalSymlinks` resolving `/var` → `/private/var`
- **Smoke test portability**: Hardcoded Linux install path, used `${var@Q}` (bash 4.4+, macOS ships 3.2), and `awk '{exit}'` caused SIGPIPE under `pipefail`

## Details

| File | Issue | Fix |
|------|-------|-----|
| `markdown_preview_helpers.go` | `previewAllowedRoots` uses `Abs+Clean` but `previewCanonicalPath` uses `EvalSymlinks` → path containment check fails on symlinked dirs | Add `EvalSymlinks` to root resolution |
| `admin_vscode_test.go` | Hardcodes `~/.config/Code/User/settings.json` (Linux) | Use `DetectPlatformDefaults()` |
| `identity_paths_test.go` | Compares raw `t.TempDir()` path against `EvalSymlinks`-resolved path | Resolve expected path before comparing |
| `smoke-install-release.sh` | Linux bin dir, `${var@Q}` syntax, `ps\|awk 'exit'` SIGPIPE | Platform helper, `sys.argv`, remove awk `exit` |

## Test plan
- [x] `make test` — all Go tests pass
- [x] `make check` — full check including smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)