### PR TITLE
fix(feishu): parse slash commands after group mention

### DIFF
--- a/internal/adapter/feishu/gateway/inbound.go
+++ b/internal/adapter/feishu/gateway/inbound.go
@@ -39,12 +39,12 @@ func ParseMessageEvent(ctx context.Context, env InboundEnv, event *larkim.P2Mess
 
 	switch strings.ToLower(stringPtr(message.MessageType)) {
 	case "text":
-		text, err := ParseTextContent(stringPtr(message.Content))
+		text, commandText, err := parseFeishuEventText(stringPtr(message.Content), message.Mentions)
 		if err != nil {
 			logInboundMessageParseFailed(gatewayID, surfaceSessionID, action.Inbound, message, "parse_text_content", err)
 			return control.Action{}, false, err
 		}
-		commandAction, handled := env.ParseTextAction(text)
+		commandAction, handled := env.ParseTextAction(commandText)
 		if handled {
 			commandAction.GatewayID = gatewayID
 			commandAction.SurfaceSessionID = surfaceSessionID
@@ -186,7 +186,7 @@ func inboundMessagePreview(message *larkim.EventMessage) string {
 	rawContent := strings.TrimSpace(stringPtr(message.Content))
 	switch messageType {
 	case "text":
-		text, err := ParseTextContent(rawContent)
+		text, _, err := parseFeishuEventText(rawContent, message.Mentions)
 		if err == nil {
 			return trimLogPreview(text)
 		}

--- a/internal/adapter/feishu/gateway/inbound_lane.go
+++ b/internal/adapter/feishu/gateway/inbound_lane.go
@@ -466,12 +466,12 @@ func PlanInboundMessageEvent(env InboundEnv, event *larkim.P2MessageReceiveV1) (
 
 	switch messageType {
 	case "text":
-		text, err := ParseTextContent(content)
+		text, commandText, err := parseFeishuEventText(content, message.Mentions)
 		if err != nil {
 			logInboundMessageParseFailed(gatewayID, surfaceSessionID, inbound, message, "parse_text_content", err)
 			return PlannedInboundMessage{}, false, err
 		}
-		commandAction, handled := env.ParseTextAction(text)
+		commandAction, handled := env.ParseTextAction(commandText)
 		if handled {
 			commandAction.GatewayID = gatewayID
 			commandAction.SurfaceSessionID = surfaceSessionID

--- a/internal/adapter/feishu/gateway/support.go
+++ b/internal/adapter/feishu/gateway/support.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"time"
 
@@ -109,4 +110,134 @@ func referencedMessageID(message *larkim.EventMessage) string {
 		targetMessageID = strings.TrimSpace(stringPtr(message.RootId))
 	}
 	return targetMessageID
+}
+
+func parseFeishuEventText(rawContent string, mentions []*larkim.MentionEvent) (displayText string, commandText string, err error) {
+	rawText, err := ParseTextContent(rawContent)
+	if err != nil {
+		return "", "", err
+	}
+	return normalizeFeishuTextMentions(rawText, mentions), normalizeFeishuCommandCandidate(rawText, mentions), nil
+}
+
+func normalizeFeishuTextMentions(rawText string, mentions []*larkim.MentionEvent) string {
+	replacements := feishuMentionReplacements(mentions)
+	if len(replacements) == 0 {
+		return rawText
+	}
+	pairs := make([]string, 0, len(replacements)*2)
+	for _, item := range replacements {
+		pairs = append(pairs, item.key, item.label)
+	}
+	return strings.NewReplacer(pairs...).Replace(rawText)
+}
+
+func normalizeFeishuCommandCandidate(rawText string, mentions []*larkim.MentionEvent) string {
+	trimmed := strings.TrimSpace(rawText)
+	if trimmed == "" {
+		return rawText
+	}
+	if commandText, ok := stripLeadingFeishuMentionKeys(trimmed, feishuMentionKeys(mentions)); ok {
+		return commandText
+	}
+	if len(mentions) == 0 && !strings.Contains(trimmed, "@_user_") {
+		return rawText
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return rawText
+	}
+	index := 0
+	for index < len(fields) && strings.HasPrefix(fields[index], "@") {
+		index++
+	}
+	if index > 0 && index < len(fields) && strings.HasPrefix(fields[index], "/") {
+		return strings.Join(fields[index:], " ")
+	}
+	return rawText
+}
+
+func stripLeadingFeishuMentionKeys(text string, keys []string) (string, bool) {
+	if len(keys) == 0 {
+		return "", false
+	}
+	rest := strings.TrimSpace(text)
+	stripped := false
+	for {
+		matched := false
+		for _, key := range keys {
+			if !strings.HasPrefix(rest, key) {
+				continue
+			}
+			next := strings.TrimLeft(rest[len(key):], " \t\r\n")
+			if next == "" {
+				return "", false
+			}
+			rest = next
+			stripped = true
+			matched = true
+			break
+		}
+		if !matched {
+			break
+		}
+	}
+	if stripped && strings.HasPrefix(rest, "/") {
+		return rest, true
+	}
+	return "", false
+}
+
+type feishuMentionReplacement struct {
+	key   string
+	label string
+}
+
+func feishuMentionKeys(mentions []*larkim.MentionEvent) []string {
+	replacements := feishuMentionReplacements(mentions)
+	keys := make([]string, 0, len(replacements))
+	for _, item := range replacements {
+		keys = append(keys, item.key)
+	}
+	return keys
+}
+
+func feishuMentionReplacements(mentions []*larkim.MentionEvent) []feishuMentionReplacement {
+	replacements := make([]feishuMentionReplacement, 0, len(mentions))
+	seen := map[string]struct{}{}
+	for _, mention := range mentions {
+		if mention == nil {
+			continue
+		}
+		key := strings.TrimSpace(stringPtr(mention.Key))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		replacements = append(replacements, feishuMentionReplacement{
+			key:   key,
+			label: feishuMentionDisplayLabel(mention, key),
+		})
+	}
+	sort.SliceStable(replacements, func(i, j int) bool {
+		return len(replacements[i].key) > len(replacements[j].key)
+	})
+	return replacements
+}
+
+func feishuMentionDisplayLabel(mention *larkim.MentionEvent, fallback string) string {
+	if mention == nil {
+		return fallback
+	}
+	name := strings.TrimSpace(stringPtr(mention.Name))
+	if name == "" {
+		return fallback
+	}
+	if strings.HasPrefix(name, "@") {
+		return name
+	}
+	return "@" + name
 }

--- a/internal/adapter/feishu/gateway_test.go
+++ b/internal/adapter/feishu/gateway_test.go
@@ -526,6 +526,57 @@ func TestParseMessageEventCommandPreservesGatewayID(t *testing.T) {
 	}
 }
 
+func TestParseMessageEventNormalizesMentionPlaceholdersInText(t *testing.T) {
+	gateway := NewLiveGateway(LiveGatewayConfig{GatewayID: "app-1"})
+	event := testTextMessageEvent("evt-mention-text-1", "om-msg-mention-1", "@_user_1 帮我看一下")
+	event.Event.Message.ChatType = stringRef("group")
+	event.Event.Message.Mentions = []*larkim.MentionEvent{{
+		Key:  stringRef("@_user_1"),
+		Name: stringRef("Codex Remote"),
+	}}
+
+	action, ok, err := gateway.parseMessageEvent(t.Context(), event)
+	if err != nil {
+		t.Fatalf("parseMessageEvent returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected text message to be handled")
+	}
+	if action.Kind != control.ActionTextMessage {
+		t.Fatalf("unexpected action kind: %#v", action)
+	}
+	if action.Text != "@Codex Remote 帮我看一下" {
+		t.Fatalf("text = %q, want normalized mention label", action.Text)
+	}
+}
+
+func TestPlanInboundMessageEventTreatsMentionedSlashCommandAsCommand(t *testing.T) {
+	gateway := NewLiveGateway(LiveGatewayConfig{GatewayID: "app-1"})
+	event := testTextMessageEvent("evt-mention-cmd-1", "om-msg-mention-cmd-1", "@_user_1 /list")
+	event.Event.Message.ChatType = stringRef("group")
+	event.Event.Message.Mentions = []*larkim.MentionEvent{{
+		Key:  stringRef("@_user_1"),
+		Name: stringRef("Codex Remote"),
+	}}
+
+	plan, ok, err := gateway.planInboundMessageEvent(event)
+	if err != nil {
+		t.Fatalf("planInboundMessageEvent returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected mentioned slash command to be handled")
+	}
+	if plan.queue != nil {
+		t.Fatalf("expected mentioned slash command to bypass queued text path, got %#v", plan)
+	}
+	if plan.action == nil || plan.action.Kind != control.ActionListInstances {
+		t.Fatalf("unexpected planned action: %#v", plan)
+	}
+	if plan.action.Text != "/list" {
+		t.Fatalf("action text = %q, want /list", plan.action.Text)
+	}
+}
+
 func TestCardTemplateUsesSemanticColors(t *testing.T) {
 	tests := map[string]string{
 		cardThemeInfo:     "grey",


### PR DESCRIPTION
## Summary
- normalize Feishu group-message mention placeholders before command parsing
- treat inputs like `@Codex Remote /list` as slash commands instead of plain text fallthrough
- add gateway tests for mention normalization and command candidate extraction

## Testing
- go test ./internal/adapter/feishu
- go test ./internal/app/daemon ./internal/core/control ./internal/core/orchestrator
