### PR TITLE
[codex] Support quoted Feishu file inputs

### DIFF
--- a/internal/adapter/feishu/gateway/inbound.go
+++ b/internal/adapter/feishu/gateway/inbound.go
@@ -14,6 +14,16 @@ import (
 	"github.com/kxn/codex-remote-feishu/internal/core/control"
 )
 
+func quotedMessageInputs(ctx context.Context, env InboundEnv, message *larkim.EventMessage) QuotedMessageInputs {
+	if env.QuotedMessageInputs != nil {
+		return env.QuotedMessageInputs(ctx, message)
+	}
+	if env.QuotedInputs != nil {
+		return QuotedMessageInputs{Inputs: env.QuotedInputs(ctx, message)}
+	}
+	return QuotedMessageInputs{}
+}
+
 func ParseMessageEvent(ctx context.Context, env InboundEnv, event *larkim.P2MessageReceiveV1) (control.Action, bool, error) {
 	if event == nil || event.Event == nil || event.Event.Message == nil {
 		return control.Action{}, false, nil
@@ -55,10 +65,12 @@ func ParseMessageEvent(ctx context.Context, env InboundEnv, event *larkim.P2Mess
 			return commandAction, true, nil
 		}
 		currentInputs := []agentproto.Input{{Type: agentproto.InputText, Text: text}}
-		inputs := append(env.QuotedInputs(ctx, message), currentInputs...)
+		quoted := quotedMessageInputs(ctx, env, message)
+		inputs := append(quoted.Inputs, currentInputs...)
 		action.Kind = control.ActionTextMessage
 		action.Text = text
 		action.Inputs = inputs
+		action.Files = append(action.Files, quoted.Files...)
 		action.SteerInputs = currentInputs
 		env.RecordSurfaceMessage(action.MessageID, surfaceSessionID)
 		return action, true, nil
@@ -72,9 +84,11 @@ func ParseMessageEvent(ctx context.Context, env InboundEnv, event *larkim.P2Mess
 			logInboundMessageIgnored(gatewayID, surfaceSessionID, action.Inbound, message, "empty_post_inputs")
 			return control.Action{}, false, nil
 		}
+		quoted := quotedMessageInputs(ctx, env, message)
 		action.Kind = control.ActionTextMessage
 		action.Text = text
-		action.Inputs = append(env.QuotedInputs(ctx, message), inputs...)
+		action.Inputs = append(quoted.Inputs, inputs...)
+		action.Files = append(action.Files, quoted.Files...)
 		action.SteerInputs = append([]agentproto.Input(nil), inputs...)
 		env.RecordSurfaceMessage(action.MessageID, surfaceSessionID)
 		return action, true, nil
@@ -121,9 +135,11 @@ func ParseMessageEvent(ctx context.Context, env InboundEnv, event *larkim.P2Mess
 			logInboundMessageIgnored(gatewayID, surfaceSessionID, action.Inbound, message, "empty_merge_forward_content")
 			return control.Action{}, false, nil
 		}
+		quoted := quotedMessageInputs(ctx, env, message)
 		action.Kind = control.ActionTextMessage
 		action.Text = summary
-		action.Inputs = append(env.QuotedInputs(ctx, message), inputs...)
+		action.Inputs = append(quoted.Inputs, inputs...)
+		action.Files = append(action.Files, quoted.Files...)
 		env.RecordSurfaceMessage(action.MessageID, surfaceSessionID)
 		return action, true, nil
 	default:

--- a/internal/adapter/feishu/gateway/inbound_lane.go
+++ b/internal/adapter/feishu/gateway/inbound_lane.go
@@ -277,9 +277,11 @@ func (w *QueuedMessageWork) parseAction(ctx context.Context, env InboundEnv) (co
 	switch strings.ToLower(strings.TrimSpace(w.messageType)) {
 	case "text":
 		currentInputs := []agentproto.Input{{Type: agentproto.InputText, Text: w.text}}
+		quoted := quotedMessageInputs(ctx, env, message)
 		action.Kind = control.ActionTextMessage
 		action.Text = w.text
-		action.Inputs = append(env.QuotedInputs(ctx, message), currentInputs...)
+		action.Inputs = append(quoted.Inputs, currentInputs...)
+		action.Files = append(action.Files, quoted.Files...)
 		action.SteerInputs = currentInputs
 		return action, true, nil
 	case "post":
@@ -290,9 +292,11 @@ func (w *QueuedMessageWork) parseAction(ctx context.Context, env InboundEnv) (co
 		if len(inputs) == 0 {
 			return control.Action{}, false, nil
 		}
+		quoted := quotedMessageInputs(ctx, env, message)
 		action.Kind = control.ActionTextMessage
 		action.Text = text
-		action.Inputs = append(env.QuotedInputs(ctx, message), inputs...)
+		action.Inputs = append(quoted.Inputs, inputs...)
+		action.Files = append(action.Files, quoted.Files...)
 		action.SteerInputs = append([]agentproto.Input(nil), inputs...)
 		return action, true, nil
 	case "image":
@@ -322,9 +326,11 @@ func (w *QueuedMessageWork) parseAction(ctx context.Context, env InboundEnv) (co
 		if len(inputs) == 0 {
 			return control.Action{}, false, nil
 		}
+		quoted := quotedMessageInputs(ctx, env, message)
 		action.Kind = control.ActionTextMessage
 		action.Text = summary
-		action.Inputs = append(env.QuotedInputs(ctx, message), inputs...)
+		action.Inputs = append(quoted.Inputs, inputs...)
+		action.Files = append(action.Files, quoted.Files...)
 		return action, true, nil
 	default:
 		return control.Action{}, false, nil

--- a/internal/adapter/feishu/gateway/types.go
+++ b/internal/adapter/feishu/gateway/types.go
@@ -14,11 +14,17 @@ type RoutingEnv struct {
 	SurfaceForCardAction func(messageID, chatID, operatorID string) string
 }
 
+type QuotedMessageInputs struct {
+	Inputs []agentproto.Input
+	Files  []control.ActionFileAttachment
+}
+
 type InboundEnv struct {
 	GatewayID                        string
 	LookupSurfaceMessage             func(messageID string) string
 	ParseTextActionWithoutCatalog    func(text string) (control.Action, bool)
 	QuotedInputs                     func(context.Context, *larkim.EventMessage) []agentproto.Input
+	QuotedMessageInputs              func(context.Context, *larkim.EventMessage) QuotedMessageInputs
 	ParsePostInputs                  func(context.Context, string, string) ([]agentproto.Input, string, error)
 	BuildMergeForwardStructuredInput func(context.Context, *larkim.EventMessage) (string, []agentproto.Input, error)
 	RecordSurfaceMessage             func(messageID, surfaceSessionID string)

--- a/internal/adapter/feishu/gateway_inbound_quoted_inputs.go
+++ b/internal/adapter/feishu/gateway_inbound_quoted_inputs.go
@@ -15,47 +15,51 @@ import (
 
 	gatewaypkg "github.com/kxn/codex-remote-feishu/internal/adapter/feishu/gateway"
 	"github.com/kxn/codex-remote-feishu/internal/core/agentproto"
+	"github.com/kxn/codex-remote-feishu/internal/core/control"
 )
 
 func (g *LiveGateway) quotedInputs(ctx context.Context, message *larkim.EventMessage) []agentproto.Input {
+	return g.quotedMessageInputs(ctx, message).Inputs
+}
+
+func (g *LiveGateway) quotedMessageInputs(ctx context.Context, message *larkim.EventMessage) gatewaypkg.QuotedMessageInputs {
 	if message == nil || g.fetchMessageFn == nil {
-		return nil
+		return gatewaypkg.QuotedMessageInputs{}
 	}
 	ctx, cancel := newFeishuTimeoutContext(ctx, inboundMessageParseTimeout)
 	defer cancel()
 
 	targetMessageID := referencedMessageID(message)
 	if targetMessageID == "" {
-		return nil
+		return gatewaypkg.QuotedMessageInputs{}
 	}
 	referenced, err := g.fetchMessageFn(ctx, targetMessageID)
 	if err != nil {
 		log.Printf("feishu quote fetch ignored: message=%s err=%v", targetMessageID, err)
-		return nil
+		return gatewaypkg.QuotedMessageInputs{}
 	}
 	return g.inputsFromReferencedMessage(ctx, referenced)
 }
-
-func (g *LiveGateway) inputsFromReferencedMessage(ctx context.Context, referenced *gatewayMessage) []agentproto.Input {
+func (g *LiveGateway) inputsFromReferencedMessage(ctx context.Context, referenced *gatewayMessage) gatewaypkg.QuotedMessageInputs {
 	if referenced == nil || referenced.Deleted {
-		return nil
+		return gatewaypkg.QuotedMessageInputs{}
 	}
 	switch strings.ToLower(strings.TrimSpace(referenced.MessageType)) {
 	case "text":
 		text, err := gatewaypkg.ParseTextContent(referenced.Content)
 		if err != nil {
 			log.Printf("feishu quote text parse ignored: message=%s err=%v", referenced.MessageID, err)
-			return nil
+			return gatewaypkg.QuotedMessageInputs{}
 		}
 		if wrapped := quotedTextInput(text); wrapped.Text != "" {
-			return []agentproto.Input{wrapped}
+			return gatewaypkg.QuotedMessageInputs{Inputs: []agentproto.Input{wrapped}}
 		}
-		return nil
+		return gatewaypkg.QuotedMessageInputs{}
 	case "post":
 		inputs, text, err := g.parsePostInputs(ctx, referenced.MessageID, referenced.Content)
 		if err != nil {
 			log.Printf("feishu quote post parse ignored: message=%s err=%v", referenced.MessageID, err)
-			return nil
+			return gatewaypkg.QuotedMessageInputs{}
 		}
 		quoted := make([]agentproto.Input, 0, len(inputs)+1)
 		if wrapped := quotedTextInput(text); wrapped.Text != "" {
@@ -66,41 +70,57 @@ func (g *LiveGateway) inputsFromReferencedMessage(ctx context.Context, reference
 				quoted = append(quoted, input)
 			}
 		}
-		return quoted
+		return gatewaypkg.QuotedMessageInputs{Inputs: quoted}
 	case "image":
 		imageKey, err := gatewaypkg.ParseImageKey(referenced.Content)
 		if err != nil {
 			log.Printf("feishu quote image parse ignored: message=%s err=%v", referenced.MessageID, err)
-			return nil
+			return gatewaypkg.QuotedMessageInputs{}
 		}
 		path, mimeType, err := g.downloadImageFn(ctx, referenced.MessageID, imageKey)
 		if err != nil {
 			log.Printf("feishu quote image download ignored: message=%s err=%v", referenced.MessageID, err)
-			return nil
+			return gatewaypkg.QuotedMessageInputs{}
 		}
-		return []agentproto.Input{{Type: agentproto.InputLocalImage, Path: path, MIMEType: mimeType}}
+		return gatewaypkg.QuotedMessageInputs{Inputs: []agentproto.Input{{Type: agentproto.InputLocalImage, Path: path, MIMEType: mimeType}}}
+	case "file":
+		fileKey, fileName, err := gatewaypkg.ParseFileContent(referenced.Content)
+		if err != nil {
+			log.Printf("feishu quote file parse ignored: message=%s err=%v", referenced.MessageID, err)
+			return gatewaypkg.QuotedMessageInputs{}
+		}
+		path, err := g.downloadFileFn(ctx, referenced.MessageID, fileKey, fileName)
+		if err != nil {
+			log.Printf("feishu quote file download ignored: message=%s err=%v", referenced.MessageID, err)
+			return gatewaypkg.QuotedMessageInputs{}
+		}
+		return gatewaypkg.QuotedMessageInputs{Files: []control.ActionFileAttachment{{
+			SourceMessageID: referenced.MessageID,
+			LocalPath:       path,
+			FileName:        fileName,
+		}}}
 	case "merge_forward":
 		payload, err := g.buildMergeForwardStructuredPayloadFromGatewayMessage(ctx, referenced, true)
 		if err != nil {
 			log.Printf("feishu quote merge_forward parse ignored: message=%s err=%v", referenced.MessageID, err)
-			return nil
+			return gatewaypkg.QuotedMessageInputs{}
 		}
 		if len(payload.Inputs) > 0 {
-			return payload.Inputs
+			return gatewaypkg.QuotedMessageInputs{Inputs: payload.Inputs}
 		}
-		return nil
+		return gatewaypkg.QuotedMessageInputs{}
 	case "interactive":
 		text, err := quotedInteractiveCardText(referenced.Content)
 		if err != nil {
 			log.Printf("feishu quote interactive parse ignored: message=%s err=%v", referenced.MessageID, err)
-			return nil
+			return gatewaypkg.QuotedMessageInputs{}
 		}
 		if wrapped := quotedTextInput(text); wrapped.Text != "" {
-			return []agentproto.Input{wrapped}
+			return gatewaypkg.QuotedMessageInputs{Inputs: []agentproto.Input{wrapped}}
 		}
-		return nil
+		return gatewaypkg.QuotedMessageInputs{}
 	default:
-		return nil
+		return gatewaypkg.QuotedMessageInputs{}
 	}
 }
 

--- a/internal/adapter/feishu/gateway_message_events_test.go
+++ b/internal/adapter/feishu/gateway_message_events_test.go
@@ -403,6 +403,57 @@ func TestParseMessageEventEnrichesReplyWithQuotedPost(t *testing.T) {
 	}
 }
 
+func TestParseMessageEventEnrichesReplyWithQuotedFile(t *testing.T) {
+	gateway := NewLiveGateway(LiveGatewayConfig{GatewayID: "app-1"})
+	gateway.fetchMessageFn = func(_ context.Context, messageID string) (*gatewayMessage, error) {
+		if messageID != "om-parent-file-1" {
+			t.Fatalf("unexpected parent file lookup: %s", messageID)
+		}
+		return &gatewayMessage{
+			MessageID:   messageID,
+			MessageType: "file",
+			Content:     `{"file_key":"file-quoted-1","file_name":"需求说明.pdf"}`,
+		}, nil
+	}
+	gateway.downloadFileFn = func(_ context.Context, messageID, fileKey, fileName string) (string, error) {
+		if messageID != "om-parent-file-1" || fileKey != "file-quoted-1" || fileName != "需求说明.pdf" {
+			t.Fatalf("unexpected quoted file download request: message=%s file=%s name=%s", messageID, fileKey, fileName)
+		}
+		return "/tmp/quoted-requirements.pdf", nil
+	}
+	event := &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId: &larkim.UserId{OpenId: stringRef("ou_user")},
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   stringRef("om-reply-file-1"),
+				ChatId:      stringRef("oc_chat"),
+				ChatType:    stringRef("group"),
+				MessageType: stringRef("text"),
+				ParentId:    stringRef("om-parent-file-1"),
+				Content:     stringRef(`{"text":"请读取我回复的文件"}`),
+			},
+		},
+	}
+
+	action, ok, err := gateway.parseMessageEvent(t.Context(), event)
+	if err != nil {
+		t.Fatalf("parseMessageEvent returned error: %v", err)
+	}
+	if !ok || action.Kind != control.ActionTextMessage {
+		t.Fatalf("expected reply text to be handled, got ok=%v action=%#v", ok, action)
+	}
+	if len(action.Files) != 1 {
+		t.Fatalf("expected one quoted file attachment, got %#v", action.Files)
+	}
+	if action.Files[0].SourceMessageID != "om-parent-file-1" || action.Files[0].LocalPath != "/tmp/quoted-requirements.pdf" || action.Files[0].FileName != "需求说明.pdf" {
+		t.Fatalf("unexpected quoted file attachment: %#v", action.Files[0])
+	}
+	if len(action.Inputs) != 1 || action.Inputs[0].Type != agentproto.InputText || action.Inputs[0].Text != "请读取我回复的文件" {
+		t.Fatalf("unexpected current text input: %#v", action.Inputs)
+	}
+}
 func TestParseMessageEventIgnoresQuoteFetchFailure(t *testing.T) {
 	gateway := NewLiveGateway(LiveGatewayConfig{GatewayID: "app-1"})
 	gateway.fetchMessageFn = func(_ context.Context, _ string) (*gatewayMessage, error) {

--- a/internal/adapter/feishu/gateway_runtime_support.go
+++ b/internal/adapter/feishu/gateway_runtime_support.go
@@ -34,6 +34,7 @@ func (g *LiveGateway) inboundEnv() gatewaypkg.InboundEnv {
 		LookupSurfaceMessage:          g.lookupSurfaceMessage,
 		ParseTextActionWithoutCatalog: control.ParseFeishuTextActionWithoutCatalog,
 		QuotedInputs:                  g.quotedInputs,
+		QuotedMessageInputs:           g.quotedMessageInputs,
 		ParsePostInputs:               g.parsePostInputs,
 		BuildMergeForwardStructuredInput: func(ctx context.Context, message *larkim.EventMessage) (string, []agentproto.Input, error) {
 			payload, err := g.buildMergeForwardStructuredPayloadFromEvent(ctx, message)

--- a/internal/app/daemon/app_inbound_file.go
+++ b/internal/app/daemon/app_inbound_file.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kxn/codex-remote-feishu/internal/core/agentproto"
 	"github.com/kxn/codex-remote-feishu/internal/core/control"
 	"github.com/kxn/codex-remote-feishu/internal/core/eventcontract"
 	"github.com/kxn/codex-remote-feishu/internal/core/state"
@@ -18,10 +19,32 @@ const (
 )
 
 func (a *App) applyIngressActionLocked(action control.Action) []eventcontract.Event {
-	if action.Kind != control.ActionFileMessage {
+	switch action.Kind {
+	case control.ActionFileMessage:
+		return a.applyIngressFileActionLocked(action)
+	case control.ActionTextMessage:
+		prepared, err := a.prepareInboundTextFilesActionLocked(action)
+		if err != nil {
+			a.ensureSurfaceRouteForNotice(action)
+			return []eventcontract.Event{{
+				Kind:             eventcontract.KindNotice,
+				GatewayID:        action.GatewayID,
+				SurfaceSessionID: action.SurfaceSessionID,
+				Notice: &control.Notice{
+					Code:     "inbound_file_prepare_failed",
+					Title:    "文件暂存失败",
+					Text:     "文件已经收到，但暂存到当前工作区时失败了，请稍后重试。",
+					ThemeKey: "error",
+				},
+			}}
+		}
+		return a.service.ApplySurfaceAction(prepared)
+	default:
 		return a.service.ApplySurfaceAction(action)
 	}
+}
 
+func (a *App) applyIngressFileActionLocked(action control.Action) []eventcontract.Event {
 	prepared, err := a.prepareInboundFileActionLocked(action)
 	if err != nil {
 		a.ensureSurfaceRouteForNotice(action)
@@ -46,7 +69,6 @@ func (a *App) applyIngressActionLocked(action control.Action) []eventcontract.Ev
 	}
 	return events
 }
-
 func (a *App) prepareInboundFileActionLocked(action control.Action) (control.Action, error) {
 	path := strings.TrimSpace(action.LocalPath)
 	if action.Kind != control.ActionFileMessage || path == "" {
@@ -78,6 +100,72 @@ func (a *App) prepareInboundFileActionLocked(action control.Action) (control.Act
 		action.FileName = filepath.Base(finalPath)
 	}
 	return action, nil
+}
+
+func (a *App) prepareInboundTextFilesActionLocked(action control.Action) (control.Action, error) {
+	if action.Kind != control.ActionTextMessage || len(action.Files) == 0 {
+		return action, nil
+	}
+	preparedFiles := make([]control.ActionFileAttachment, 0, len(action.Files))
+	for _, file := range action.Files {
+		path := strings.TrimSpace(file.LocalPath)
+		if path == "" {
+			continue
+		}
+		sourceMessageID := strings.TrimSpace(file.SourceMessageID)
+		if sourceMessageID == "" {
+			sourceMessageID = action.MessageID
+		}
+		prepared, err := a.prepareInboundFileActionLocked(control.Action{
+			Kind:             control.ActionFileMessage,
+			GatewayID:        action.GatewayID,
+			SurfaceSessionID: action.SurfaceSessionID,
+			ChatID:           action.ChatID,
+			ActorUserID:      action.ActorUserID,
+			MessageID:        sourceMessageID,
+			LocalPath:        path,
+			FileName:         file.FileName,
+			Inbound:          action.Inbound,
+		})
+		if err != nil {
+			return action, err
+		}
+		if strings.TrimSpace(prepared.LocalPath) == "" {
+			continue
+		}
+		preparedFiles = append(preparedFiles, control.ActionFileAttachment{
+			SourceMessageID: sourceMessageID,
+			LocalPath:       prepared.LocalPath,
+			FileName:        prepared.FileName,
+		})
+	}
+	if prompt := inboundFileAttachmentPrompt(preparedFiles); prompt != "" {
+		fileInput := agentproto.Input{Type: agentproto.InputText, Text: prompt}
+		action.Inputs = append([]agentproto.Input{fileInput}, action.Inputs...)
+	}
+	return action, nil
+}
+
+func inboundFileAttachmentPrompt(files []control.ActionFileAttachment) string {
+	if len(files) == 0 {
+		return ""
+	}
+	lines := []string{"附带参考文件（内容未直接注入上下文，可按需读取以下本地路径）："}
+	for _, file := range files {
+		path := strings.TrimSpace(file.LocalPath)
+		if path == "" {
+			continue
+		}
+		name := strings.TrimSpace(file.FileName)
+		if name == "" {
+			name = filepath.Base(path)
+		}
+		lines = append(lines, fmt.Sprintf("- %s: %s", name, path))
+	}
+	if len(lines) == 1 {
+		return ""
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (a *App) inboundFileRetainedLocked(surfaceID, sourceMessageID, path string) bool {

--- a/internal/app/daemon/app_inbound_file_test.go
+++ b/internal/app/daemon/app_inbound_file_test.go
@@ -76,6 +76,74 @@ func TestHandleFileActionMaterializesIntoWorkspaceAndUpdatesGitExclude(t *testin
 	}
 }
 
+func TestHandleTextActionWithQuotedFileMaterializesIntoWorkspaceInput(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, ".git", "info"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git/info): %v", err)
+	}
+	incomingDir := t.TempDir()
+	incomingPath := filepath.Join(incomingDir, "requirements.pdf")
+	if err := os.WriteFile(incomingPath, []byte("hello quoted file"), 0o600); err != nil {
+		t.Fatalf("WriteFile(incoming): %v", err)
+	}
+
+	app := New(":0", ":0", &recordingGateway{}, serverIdentityForTest())
+	app.service.UpsertInstance(&state.InstanceRecord{
+		InstanceID:    "inst-1",
+		DisplayName:   "repo",
+		WorkspaceRoot: workspaceRoot,
+		WorkspaceKey:  workspaceRoot,
+		ShortName:     "repo",
+		Online:        true,
+		Threads:       map[string]*state.ThreadRecord{},
+	})
+	app.service.ApplySurfaceAction(control.Action{Kind: control.ActionAttachInstance, SurfaceSessionID: "surface-1", ChatID: "chat-1", ActorUserID: "user-1", InstanceID: "inst-1"})
+
+	app.handleAction(context.Background(), control.Action{
+		Kind:             control.ActionTextMessage,
+		GatewayID:        "app-1",
+		SurfaceSessionID: "surface-1",
+		ChatID:           "chat-1",
+		ActorUserID:      "user-1",
+		MessageID:        "msg-text-1",
+		Text:             "请读取我回复的文件",
+		Inputs:           []agentproto.Input{{Type: agentproto.InputText, Text: "请读取我回复的文件"}},
+		Files: []control.ActionFileAttachment{{
+			SourceMessageID: "msg-file-quoted-1",
+			LocalPath:       incomingPath,
+			FileName:        "requirements.pdf",
+		}},
+	})
+
+	surface := app.service.Surface("surface-1")
+	if surface == nil || len(surface.QueueItems) != 1 {
+		t.Fatalf("expected one queued item, got %#v", surface)
+	}
+	var item *state.QueueItemRecord
+	for _, current := range surface.QueueItems {
+		item = current
+	}
+	if item == nil {
+		t.Fatal("expected queued item")
+	}
+	wantPath := filepath.Join(workspaceRoot, ".codex-remote", "inbox", "feishu-files", "msg-file-quoted-1", "requirements.pdf")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected quoted file to be materialized: %v", err)
+	}
+	if _, err := os.Stat(incomingPath); !os.IsNotExist(err) {
+		t.Fatalf("expected original temp file to be moved away, got err=%v", err)
+	}
+	if len(item.Inputs) != 2 {
+		t.Fatalf("expected file reference prompt + user text, got %#v", item.Inputs)
+	}
+	if item.Inputs[0].Type != agentproto.InputText || !strings.Contains(item.Inputs[0].Text, "requirements.pdf") || !strings.Contains(item.Inputs[0].Text, wantPath) {
+		t.Fatalf("unexpected quoted file prompt: %#v", item.Inputs[0])
+	}
+	if item.Inputs[1].Type != agentproto.InputText || item.Inputs[1].Text != "请读取我回复的文件" {
+		t.Fatalf("unexpected user text input: %#v", item.Inputs[1])
+	}
+}
+
 func TestHandleFileActionWithoutAttachmentCleansTempFile(t *testing.T) {
 	incomingDir := t.TempDir()
 	incomingPath := filepath.Join(incomingDir, "spec.pdf")

--- a/internal/core/control/types.go
+++ b/internal/core/control/types.go
@@ -115,6 +115,12 @@ type ActionInboundMeta struct {
 	LifecycleReason       string
 }
 
+type ActionFileAttachment struct {
+	SourceMessageID string
+	LocalPath       string
+	FileName        string
+}
+
 type Action struct {
 	Kind                ActionKind
 	GatewayID           string
@@ -125,6 +131,7 @@ type Action struct {
 	Text                string
 	Inputs              []agentproto.Input
 	SteerInputs         []agentproto.Input
+	Files               []ActionFileAttachment
 	RequestAnswers      map[string][]string
 	OptionID            string
 	Request             *ActionRequestResponse


### PR DESCRIPTION
## Summary

- Add quoted Feishu file attachments to inbound text actions.
- Materialize quoted files into the active workspace inbox before sending the prompt to Codex.
- Cover quoted file parsing and workspace materialization with unit tests.

## Root Cause

Feishu group chats often require users to send a file first, then reply to that file message while mentioning the bot. The existing quoted-message enrichment path handled text, post, image, merge-forward, and interactive cards, but it ignored quoted `file` messages. As a result, Codex only received the follow-up text and had no stable local path for the referenced file.

## Implementation

Quoted file messages are now downloaded by the Feishu gateway and carried as `ActionFileAttachment` metadata on the inbound text action. The daemon then reuses the existing file-message materialization flow to move the file into:

`<workspace>/.codex-remote/inbox/feishu-files/<message-id>/<filename>`

The generated text input points Codex at that workspace-local path, matching the behavior of direct file uploads.

## Validation

- `go test ./internal/adapter/feishu ./internal/app/daemon ./internal/core/control -count=1`
- `go test ./... -count=1`
- `go build -o ./bin/codex-remote ./cmd/codex-remote`
- Installed locally and verified the Feishu group reply-file workflow end to end.
