### PR TITLE
refactor(daemon): converge state store templates into generic statestore

### DIFF
--- a/internal/app/daemon/botcapabilitysettings/state.go
+++ b/internal/app/daemon/botcapabilitysettings/state.go
@@ -1,12 +1,9 @@
 package botcapabilitysettings
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
+	"github.com/kxn/codex-remote-feishu/internal/app/daemon/statestore"
 	"github.com/kxn/codex-remote-feishu/internal/core/state"
 )
 
@@ -15,96 +12,41 @@ const (
 	StateFileName = "bot-capability-settings.json"
 )
 
-type StateFile struct {
-	Version int                                          `json:"version"`
-	Entries map[string]state.BotCapabilitySettingsRecord `json:"entries,omitempty"`
-}
-
-type Store struct {
-	path    string
-	entries map[string]state.BotCapabilitySettingsRecord
-	dirty   bool
-}
+type Record = state.BotCapabilitySettingsRecord
 
 func StatePath(stateDir string) string {
-	stateDir = strings.TrimSpace(stateDir)
-	if stateDir == "" {
-		return ""
-	}
-	return filepath.Join(stateDir, StateFileName)
+	return statestore.StatePath(stateDir, StateFileName)
 }
 
 func NewStore(path string) *Store {
-	return &Store{
-		path:    strings.TrimSpace(path),
-		entries: map[string]state.BotCapabilitySettingsRecord{},
-	}
+	return &Store{Store: statestore.New[Record](path, statestore.Options[Record]{
+		Version:       StateVersion,
+		Name:          "bot capability settings",
+		Equal:         func(left, right Record) bool { return left == right },
+		LoadNormalize: state.NormalizeBotCapabilitySettingsRecord,
+		LoadKey:       func(record Record) string { return state.BotCapabilitySettingsKey(record.GatewayID) },
+	})}
 }
 
 func LoadStore(path string) (*Store, error) {
-	store := NewStore(path)
-	if store.path == "" {
-		return store, nil
-	}
-	raw, err := os.ReadFile(store.path)
+	store, err := statestore.Load[Record](path, statestore.Options[Record]{
+		Version:       StateVersion,
+		Name:          "bot capability settings",
+		Equal:         func(left, right Record) bool { return left == right },
+		LoadNormalize: state.NormalizeBotCapabilitySettingsRecord,
+		LoadKey:       func(record Record) string { return state.BotCapabilitySettingsKey(record.GatewayID) },
+	})
 	if err != nil {
-		if os.IsNotExist(err) {
-			return store, nil
-		}
 		return nil, err
 	}
-	var persisted StateFile
-	if err := json.Unmarshal(raw, &persisted); err != nil {
-		return nil, err
-	}
-	if persisted.Version == 0 {
-		persisted.Version = StateVersion
-	}
-	if persisted.Version != StateVersion {
-		return nil, fmt.Errorf("unsupported bot capability settings state version: %d", persisted.Version)
-	}
-	for key, record := range persisted.Entries {
-		normalized, ok := state.NormalizeBotCapabilitySettingsRecord(record)
-		if !ok {
-			store.dirty = true
-			continue
-		}
-		canonicalKey := state.BotCapabilitySettingsKey(normalized.GatewayID)
-		if canonicalKey == "" {
-			store.dirty = true
-			continue
-		}
-		if strings.TrimSpace(key) != canonicalKey {
-			store.dirty = true
-		}
-		store.entries[canonicalKey] = normalized
-	}
-	return store, nil
+	return &Store{Store: store}, nil
 }
 
-func (s *Store) Entries() map[string]state.BotCapabilitySettingsRecord {
-	if s == nil || len(s.entries) == 0 {
-		return map[string]state.BotCapabilitySettingsRecord{}
-	}
-	values := make(map[string]state.BotCapabilitySettingsRecord, len(s.entries))
-	for key, record := range s.entries {
-		values[key] = record
-	}
-	return values
+type Store struct {
+	*statestore.Store[Record]
 }
 
-func (s *Store) Get(key string) (state.BotCapabilitySettingsRecord, bool) {
-	if s == nil {
-		return state.BotCapabilitySettingsRecord{}, false
-	}
-	record, ok := s.entries[strings.TrimSpace(key)]
-	if !ok {
-		return state.BotCapabilitySettingsRecord{}, false
-	}
-	return record, true
-}
-
-func (s *Store) Put(record state.BotCapabilitySettingsRecord) error {
+func (s *Store) Put(record Record) error {
 	if s == nil {
 		return nil
 	}
@@ -119,14 +61,14 @@ func (s *Store) Put(record state.BotCapabilitySettingsRecord) error {
 	}
 	entries := s.Entries()
 	entries[key] = normalized
-	return s.replaceEntries(entries)
+	return s.Replace(entries)
 }
 
-func (s *Store) ReplaceAll(records []state.BotCapabilitySettingsRecord) error {
+func (s *Store) ReplaceAll(records []Record) error {
 	if s == nil {
 		return nil
 	}
-	entries := make(map[string]state.BotCapabilitySettingsRecord, len(records))
+	entries := make(map[string]Record, len(records))
 	for _, record := range records {
 		record = state.CanonicalizeBotCapabilityProfileSelection(record)
 		normalized, ok := state.NormalizeBotCapabilitySettingsRecord(record)
@@ -135,78 +77,5 @@ func (s *Store) ReplaceAll(records []state.BotCapabilitySettingsRecord) error {
 		}
 		entries[state.BotCapabilitySettingsKey(normalized.GatewayID)] = normalized
 	}
-	return s.replaceEntries(entries)
-}
-
-func (s *Store) replaceEntries(entries map[string]state.BotCapabilitySettingsRecord) error {
-	if sameEntries(s.entries, entries) {
-		return nil
-	}
-	previous := s.entries
-	s.entries = entries
-	if err := s.Save(); err != nil {
-		s.entries = previous
-		return err
-	}
-	return nil
-}
-
-func sameEntries(left, right map[string]state.BotCapabilitySettingsRecord) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for key, leftRecord := range left {
-		rightRecord, ok := right[key]
-		if !ok || leftRecord != rightRecord {
-			return false
-		}
-	}
-	return true
-}
-
-func (s *Store) Save() error {
-	if s == nil || s.path == "" {
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
-		return err
-	}
-	persisted := StateFile{
-		Version: StateVersion,
-		Entries: s.Entries(),
-	}
-	raw, err := json.MarshalIndent(persisted, "", "  ")
-	if err != nil {
-		return err
-	}
-	raw = append(raw, '\n')
-	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-	if err := tmpFile.Chmod(0o600); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if _, err := tmpFile.Write(raw); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if err := tmpFile.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, s.path); err != nil {
-		return err
-	}
-	s.dirty = false
-	return nil
-}
-
-func (s *Store) Dirty() bool {
-	if s == nil {
-		return false
-	}
-	return s.dirty
+	return s.Replace(entries)
 }

--- a/internal/app/daemon/claudeworkspaceprofile/state.go
+++ b/internal/app/daemon/claudeworkspaceprofile/state.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
+	"github.com/kxn/codex-remote-feishu/internal/app/daemon/statestore"
 	"github.com/kxn/codex-remote-feishu/internal/core/state"
 )
 
@@ -15,43 +15,26 @@ const (
 	StateFileName = "claude-workspace-profile-state.json"
 )
 
-type StateFile struct {
-	Version int                                                   `json:"version"`
-	Entries map[string]state.ClaudeWorkspaceProfileSnapshotRecord `json:"entries,omitempty"`
-}
+type Record = state.ClaudeWorkspaceProfileSnapshotRecord
 
-type rawStateFile struct {
-	Version int                        `json:"version"`
-	Entries map[string]json.RawMessage `json:"entries,omitempty"`
-}
-
-type Store struct {
-	path    string
-	entries map[string]state.ClaudeWorkspaceProfileSnapshotRecord
-	dirty   bool
+func StatePath(stateDir string) string {
+	return statestore.StatePath(stateDir, StateFileName)
 }
 
 func NewStore(path string) *Store {
-	return &Store{
-		path:    strings.TrimSpace(path),
-		entries: map[string]state.ClaudeWorkspaceProfileSnapshotRecord{},
-	}
-}
-
-func StatePath(stateDir string) string {
-	stateDir = strings.TrimSpace(stateDir)
-	if stateDir == "" {
-		return ""
-	}
-	return filepath.Join(stateDir, StateFileName)
+	return &Store{Store: statestore.New[Record](path, statestore.Options[Record]{
+		Version: StateVersion,
+		Name:    "claude workspace profile",
+		Equal:   func(left, right Record) bool { return left == right },
+	})}
 }
 
 func LoadStore(path string) (*Store, error) {
 	store := NewStore(path)
-	if store.path == "" {
+	if store.Path() == "" {
 		return store, nil
 	}
-	raw, err := os.ReadFile(store.path)
+	raw, err := os.ReadFile(store.Path())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return store, nil
@@ -68,23 +51,30 @@ func LoadStore(path string) (*Store, error) {
 	if persisted.Version != StateVersion {
 		return nil, fmt.Errorf("unsupported claude workspace profile state version: %d", persisted.Version)
 	}
+	entries := map[string]Record{}
 	for key, rawEntry := range persisted.Entries {
 		key = strings.TrimSpace(key)
 		if claudeSnapshotHasExtraneousFields(rawEntry) {
-			store.dirty = true
+			store.MarkDirty()
 		}
-		var entry state.ClaudeWorkspaceProfileSnapshotRecord
+		var entry Record
 		if err := json.Unmarshal(rawEntry, &entry); err != nil {
 			return nil, err
 		}
 		entry = state.NormalizeClaudeWorkspaceProfileSnapshotRecord(entry)
 		if key == "" || state.ClaudeWorkspaceProfileSnapshotRecordEmpty(entry) {
-			store.dirty = true
+			store.MarkDirty()
 			continue
 		}
-		store.entries[key] = entry
+		entries[key] = entry
 	}
+	store.SetEntries(entries)
 	return store, nil
+}
+
+type rawStateFile struct {
+	Version int                        `json:"version"`
+	Entries map[string]json.RawMessage `json:"entries,omitempty"`
 }
 
 func claudeSnapshotHasExtraneousFields(rawEntry json.RawMessage) bool {
@@ -103,29 +93,11 @@ func claudeSnapshotHasExtraneousFields(rawEntry json.RawMessage) bool {
 	return false
 }
 
-func (s *Store) Entries() map[string]state.ClaudeWorkspaceProfileSnapshotRecord {
-	if s == nil || len(s.entries) == 0 {
-		return map[string]state.ClaudeWorkspaceProfileSnapshotRecord{}
-	}
-	values := make(map[string]state.ClaudeWorkspaceProfileSnapshotRecord, len(s.entries))
-	for key, entry := range s.entries {
-		values[key] = entry
-	}
-	return values
+type Store struct {
+	*statestore.Store[Record]
 }
 
-func (s *Store) Get(key string) (state.ClaudeWorkspaceProfileSnapshotRecord, bool) {
-	if s == nil {
-		return state.ClaudeWorkspaceProfileSnapshotRecord{}, false
-	}
-	entry, ok := s.entries[strings.TrimSpace(key)]
-	if !ok {
-		return state.ClaudeWorkspaceProfileSnapshotRecord{}, false
-	}
-	return entry, true
-}
-
-func (s *Store) Put(key string, entry state.ClaudeWorkspaceProfileSnapshotRecord) error {
+func (s *Store) Put(key string, entry Record) error {
 	if s == nil {
 		return nil
 	}
@@ -135,64 +107,20 @@ func (s *Store) Put(key string, entry state.ClaudeWorkspaceProfileSnapshotRecord
 		return fmt.Errorf("claude workspace profile snapshot requires key")
 	}
 	if state.ClaudeWorkspaceProfileSnapshotRecordEmpty(entry) {
-		delete(s.entries, key)
-		return s.Save()
+		entries := s.Entries()
+		delete(entries, key)
+		return s.Replace(entries)
 	}
-	s.entries[key] = entry
-	return s.Save()
+	entries := s.Entries()
+	entries[key] = entry
+	return s.Replace(entries)
 }
 
 func (s *Store) Delete(key string) error {
 	if s == nil {
 		return nil
 	}
-	delete(s.entries, strings.TrimSpace(key))
-	return s.Save()
-}
-
-func (s *Store) Save() error {
-	if s == nil || s.path == "" {
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
-		return err
-	}
-	persisted := StateFile{
-		Version: StateVersion,
-		Entries: s.Entries(),
-	}
-	raw, err := json.MarshalIndent(persisted, "", "  ")
-	if err != nil {
-		return err
-	}
-	raw = append(raw, '\n')
-	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-	if err := tmpFile.Chmod(0o600); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if _, err := tmpFile.Write(raw); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if err := tmpFile.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, s.path); err != nil {
-		return err
-	}
-	s.dirty = false
-	return nil
-}
-
-func (s *Store) Dirty() bool {
-	if s == nil {
-		return false
-	}
-	return s.dirty
+	entries := s.Entries()
+	delete(entries, strings.TrimSpace(key))
+	return s.Replace(entries)
 }

--- a/internal/app/daemon/feishubotidentity/state.go
+++ b/internal/app/daemon/feishubotidentity/state.go
@@ -1,12 +1,11 @@
 package feishubotidentity
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/kxn/codex-remote-feishu/internal/app/daemon/statestore"
 )
 
 const (
@@ -27,66 +26,40 @@ type PendingTransition struct {
 	StartedAt    time.Time `json:"startedAt,omitempty"`
 }
 
-type StateFile struct {
-	Version int               `json:"version"`
-	Entries map[string]Record `json:"entries,omitempty"`
-}
-
-type Store struct {
-	path    string
-	entries map[string]Record
-	dirty   bool
-}
-
 func StatePath(stateDir string) string {
-	stateDir = strings.TrimSpace(stateDir)
-	if stateDir == "" {
-		return ""
-	}
-	return filepath.Join(stateDir, StateFileName)
+	return statestore.StatePath(stateDir, StateFileName)
 }
 
 func NewStore(path string) *Store {
-	return &Store{
-		path:    strings.TrimSpace(path),
-		entries: map[string]Record{},
-	}
+	return &Store{Store: statestore.New[Record](path, statestore.Options[Record]{
+		Version:       StateVersion,
+		Name:          "feishu bot identity",
+		Equal:         sameRecord,
+		Clone:         cloneRecord,
+		LoadNormalize: func(record Record) (Record, bool) { return NormalizeRecord(record) },
+		LoadKey:       func(record Record) string { return record.GatewayID },
+		LoadEqual:     sameRecord,
+	})}
 }
 
 func LoadStore(path string) (*Store, error) {
-	store := NewStore(path)
-	if store.path == "" {
-		return store, nil
-	}
-	raw, err := os.ReadFile(store.path)
+	store, err := statestore.Load[Record](path, statestore.Options[Record]{
+		Version:       StateVersion,
+		Name:          "feishu bot identity",
+		Equal:         sameRecord,
+		Clone:         cloneRecord,
+		LoadNormalize: func(record Record) (Record, bool) { return NormalizeRecord(record) },
+		LoadKey:       func(record Record) string { return record.GatewayID },
+		LoadEqual:     sameRecord,
+	})
 	if err != nil {
-		if os.IsNotExist(err) {
-			return store, nil
-		}
 		return nil, err
 	}
-	var persisted StateFile
-	if err := json.Unmarshal(raw, &persisted); err != nil {
-		return nil, err
-	}
-	if persisted.Version == 0 {
-		persisted.Version = StateVersion
-	}
-	if persisted.Version != StateVersion {
-		return nil, fmt.Errorf("unsupported feishu bot identity state version: %d", persisted.Version)
-	}
-	for key, record := range persisted.Entries {
-		normalized, ok := NormalizeRecord(record)
-		if !ok {
-			store.dirty = true
-			continue
-		}
-		if strings.TrimSpace(key) != normalized.GatewayID || !sameRecord(record, normalized) {
-			store.dirty = true
-		}
-		store.entries[normalized.GatewayID] = normalized
-	}
-	return store, nil
+	return &Store{Store: store}, nil
+}
+
+type Store struct {
+	*statestore.Store[Record]
 }
 
 func NormalizeRecord(record Record) (Record, bool) {
@@ -114,25 +87,6 @@ func NormalizeRecord(record Record) (Record, bool) {
 	return record, true
 }
 
-func (s *Store) Entries() map[string]Record {
-	if s == nil || len(s.entries) == 0 {
-		return map[string]Record{}
-	}
-	entries := make(map[string]Record, len(s.entries))
-	for key, record := range s.entries {
-		entries[key] = cloneRecord(record)
-	}
-	return entries
-}
-
-func (s *Store) Get(gatewayID string) (Record, bool) {
-	if s == nil {
-		return Record{}, false
-	}
-	record, ok := s.entries[strings.TrimSpace(gatewayID)]
-	return cloneRecord(record), ok
-}
-
 func (s *Store) Put(record Record) error {
 	if s == nil {
 		return nil
@@ -143,7 +97,7 @@ func (s *Store) Put(record Record) error {
 	}
 	entries := s.Entries()
 	entries[normalized.GatewayID] = normalized
-	return s.replaceEntries(entries)
+	return s.Replace(entries)
 }
 
 func (s *Store) Delete(gatewayID string) error {
@@ -154,38 +108,12 @@ func (s *Store) Delete(gatewayID string) error {
 	if gatewayID == "" {
 		return nil
 	}
-	if _, ok := s.entries[gatewayID]; !ok {
+	if _, ok := s.Get(gatewayID); !ok {
 		return nil
 	}
 	entries := s.Entries()
 	delete(entries, gatewayID)
-	return s.replaceEntries(entries)
-}
-
-func (s *Store) replaceEntries(entries map[string]Record) error {
-	if sameEntries(s.entries, entries) {
-		return nil
-	}
-	previous := s.entries
-	s.entries = entries
-	if err := s.Save(); err != nil {
-		s.entries = previous
-		return err
-	}
-	return nil
-}
-
-func sameEntries(left, right map[string]Record) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for key, leftRecord := range left {
-		rightRecord, ok := right[key]
-		if !ok || !sameRecord(leftRecord, rightRecord) {
-			return false
-		}
-	}
-	return true
+	return s.Replace(entries)
 }
 
 func sameRecord(left, right Record) bool {
@@ -213,45 +141,4 @@ func samePending(left, right *PendingTransition) bool {
 	}
 	return strings.TrimSpace(left.DesiredAppID) == strings.TrimSpace(right.DesiredAppID) &&
 		left.StartedAt.Equal(right.StartedAt)
-}
-
-func (s *Store) Save() error {
-	if s == nil || s.path == "" {
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
-		return err
-	}
-	persisted := StateFile{Version: StateVersion, Entries: s.Entries()}
-	raw, err := json.MarshalIndent(persisted, "", "  ")
-	if err != nil {
-		return err
-	}
-	raw = append(raw, '\n')
-	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-	if err := tmpFile.Chmod(0o600); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if _, err := tmpFile.Write(raw); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if err := tmpFile.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, s.path); err != nil {
-		return err
-	}
-	s.dirty = false
-	return nil
-}
-
-func (s *Store) Dirty() bool {
-	return s != nil && s.dirty
 }

--- a/internal/app/daemon/feishuroomstate/state.go
+++ b/internal/app/daemon/feishuroomstate/state.go
@@ -1,12 +1,9 @@
 package feishuroomstate
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
+	"github.com/kxn/codex-remote-feishu/internal/app/daemon/statestore"
 	"github.com/kxn/codex-remote-feishu/internal/core/state"
 )
 
@@ -17,102 +14,51 @@ const (
 	StateFileName = "feishu-room-primary.json"
 )
 
-type StateFile struct {
-	Version int                                    `json:"version"`
-	Entries map[string]state.FeishuRoomStateRecord `json:"entries,omitempty"`
-}
-
-type Store struct {
-	path    string
-	entries map[string]state.FeishuRoomStateRecord
-	dirty   bool
-}
+type Record = state.FeishuRoomStateRecord
 
 func StatePath(stateDir string) string {
-	stateDir = strings.TrimSpace(stateDir)
-	if stateDir == "" {
-		return ""
-	}
-	return filepath.Join(stateDir, StateFileName)
+	return statestore.StatePath(stateDir, StateFileName)
 }
 
 func NewStore(path string) *Store {
-	return &Store{
-		path:    strings.TrimSpace(path),
-		entries: map[string]state.FeishuRoomStateRecord{},
-	}
+	return &Store{Store: statestore.New[Record](path, statestore.Options[Record]{
+		Version:         StateVersion,
+		Name:            "feishu room state",
+		Equal:           sameRecord,
+		LoadNormalize:   func(record Record) (Record, bool) { return state.NormalizeFeishuRoomStateRecord(record) },
+		LoadKey:         func(record Record) string { return state.FeishuRoomKey(record.RoomID) },
+		LoadEqual:       sameRecord,
+		DefaultVersion:  legacyStateVersion,
+		LegacyVersions:  []int{legacyStateVersion},
+	})}
 }
 
 func LoadStore(path string) (*Store, error) {
-	store := NewStore(path)
-	if store.path == "" {
-		return store, nil
-	}
-	raw, err := os.ReadFile(store.path)
+	store, err := statestore.Load[Record](path, statestore.Options[Record]{
+		Version:         StateVersion,
+		Name:            "feishu room state",
+		Equal:           sameRecord,
+		LoadNormalize:   func(record Record) (Record, bool) { return state.NormalizeFeishuRoomStateRecord(record) },
+		LoadKey:         func(record Record) string { return state.FeishuRoomKey(record.RoomID) },
+		LoadEqual:       sameRecord,
+		DefaultVersion:  legacyStateVersion,
+		LegacyVersions:  []int{legacyStateVersion},
+	})
 	if err != nil {
-		if os.IsNotExist(err) {
-			return store, nil
-		}
 		return nil, err
 	}
-	var persisted StateFile
-	if err := json.Unmarshal(raw, &persisted); err != nil {
-		return nil, err
-	}
-	if persisted.Version == 0 {
-		persisted.Version = legacyStateVersion
-	}
-	if persisted.Version != legacyStateVersion && persisted.Version != StateVersion {
-		return nil, fmt.Errorf("unsupported feishu room state version: %d", persisted.Version)
-	}
-	if persisted.Version == legacyStateVersion {
-		store.dirty = true
-	}
-	for key, record := range persisted.Entries {
-		normalized, ok := state.NormalizeFeishuRoomStateRecord(record)
-		if !ok {
-			store.dirty = true
-			continue
-		}
-		canonicalKey := state.FeishuRoomKey(normalized.RoomID)
-		if canonicalKey == "" {
-			store.dirty = true
-			continue
-		}
-		if strings.TrimSpace(key) != canonicalKey {
-			store.dirty = true
-		}
-		if !sameRecord(record, normalized) {
-			store.dirty = true
-		}
-		store.entries[canonicalKey] = normalized
-	}
-	return store, nil
+	return &Store{Store: store}, nil
 }
 
-func (s *Store) Entries() map[string]state.FeishuRoomStateRecord {
-	if s == nil || len(s.entries) == 0 {
-		return map[string]state.FeishuRoomStateRecord{}
-	}
-	values := make(map[string]state.FeishuRoomStateRecord, len(s.entries))
-	for key, record := range s.entries {
-		values[key] = record
-	}
-	return values
+type Store struct {
+	*statestore.Store[Record]
 }
 
-func (s *Store) Get(key string) (state.FeishuRoomStateRecord, bool) {
-	if s == nil {
-		return state.FeishuRoomStateRecord{}, false
-	}
-	record, ok := s.entries[state.FeishuRoomKey(key)]
-	if !ok {
-		return state.FeishuRoomStateRecord{}, false
-	}
-	return record, true
+func (s *Store) Get(key string) (Record, bool) {
+	return s.Store.Get(state.FeishuRoomKey(key))
 }
 
-func (s *Store) Put(record state.FeishuRoomStateRecord) error {
+func (s *Store) Put(record Record) error {
 	if s == nil {
 		return nil
 	}
@@ -126,7 +72,7 @@ func (s *Store) Put(record state.FeishuRoomStateRecord) error {
 	}
 	entries := s.Entries()
 	entries[key] = normalized
-	return s.replaceEntries(entries)
+	return s.Replace(entries)
 }
 
 func (s *Store) Delete(key string) error {
@@ -137,19 +83,19 @@ func (s *Store) Delete(key string) error {
 	if key == "" {
 		return nil
 	}
-	if _, ok := s.entries[key]; !ok {
+	if _, ok := s.Get(key); !ok {
 		return nil
 	}
 	entries := s.Entries()
 	delete(entries, key)
-	return s.replaceEntries(entries)
+	return s.Replace(entries)
 }
 
-func (s *Store) ReplaceAll(records []state.FeishuRoomStateRecord) error {
+func (s *Store) ReplaceAll(records []Record) error {
 	if s == nil {
 		return nil
 	}
-	entries := make(map[string]state.FeishuRoomStateRecord, len(records))
+	entries := make(map[string]Record, len(records))
 	for _, record := range records {
 		normalized, ok := state.NormalizeFeishuRoomStateRecord(record)
 		if !ok {
@@ -157,36 +103,10 @@ func (s *Store) ReplaceAll(records []state.FeishuRoomStateRecord) error {
 		}
 		entries[state.FeishuRoomKey(normalized.RoomID)] = normalized
 	}
-	return s.replaceEntries(entries)
+	return s.Replace(entries)
 }
 
-func (s *Store) replaceEntries(entries map[string]state.FeishuRoomStateRecord) error {
-	if sameEntries(s.entries, entries) {
-		return nil
-	}
-	previous := s.entries
-	s.entries = entries
-	if err := s.Save(); err != nil {
-		s.entries = previous
-		return err
-	}
-	return nil
-}
-
-func sameEntries(left, right map[string]state.FeishuRoomStateRecord) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for key, leftRecord := range left {
-		rightRecord, ok := right[key]
-		if !ok || !sameRecord(leftRecord, rightRecord) {
-			return false
-		}
-	}
-	return true
-}
-
-func sameRecord(left, right state.FeishuRoomStateRecord) bool {
+func sameRecord(left, right Record) bool {
 	return left.RoomID == right.RoomID &&
 		left.ChatID == right.ChatID &&
 		left.WorkspaceKey == right.WorkspaceKey &&
@@ -204,51 +124,4 @@ func intPointerEqual(left, right *int) bool {
 		return left == nil && right == nil
 	}
 	return *left == *right
-}
-
-func (s *Store) Save() error {
-	if s == nil || s.path == "" {
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
-		return err
-	}
-	persisted := StateFile{
-		Version: StateVersion,
-		Entries: s.Entries(),
-	}
-	raw, err := json.MarshalIndent(persisted, "", "  ")
-	if err != nil {
-		return err
-	}
-	raw = append(raw, '\n')
-	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-	if err := tmpFile.Chmod(0o600); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if _, err := tmpFile.Write(raw); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if err := tmpFile.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, s.path); err != nil {
-		return err
-	}
-	s.dirty = false
-	return nil
-}
-
-func (s *Store) Dirty() bool {
-	if s == nil {
-		return false
-	}
-	return s.dirty
 }

--- a/internal/app/daemon/feishuroomstate/state.go
+++ b/internal/app/daemon/feishuroomstate/state.go
@@ -22,27 +22,27 @@ func StatePath(stateDir string) string {
 
 func NewStore(path string) *Store {
 	return &Store{Store: statestore.New[Record](path, statestore.Options[Record]{
-		Version:         StateVersion,
-		Name:            "feishu room state",
-		Equal:           sameRecord,
-		LoadNormalize:   func(record Record) (Record, bool) { return state.NormalizeFeishuRoomStateRecord(record) },
-		LoadKey:         func(record Record) string { return state.FeishuRoomKey(record.RoomID) },
-		LoadEqual:       sameRecord,
-		DefaultVersion:  legacyStateVersion,
-		LegacyVersions:  []int{legacyStateVersion},
+		Version:        StateVersion,
+		Name:           "feishu room state",
+		Equal:          sameRecord,
+		LoadNormalize:  func(record Record) (Record, bool) { return state.NormalizeFeishuRoomStateRecord(record) },
+		LoadKey:        func(record Record) string { return state.FeishuRoomKey(record.RoomID) },
+		LoadEqual:      sameRecord,
+		DefaultVersion: legacyStateVersion,
+		LegacyVersions: []int{legacyStateVersion},
 	})}
 }
 
 func LoadStore(path string) (*Store, error) {
 	store, err := statestore.Load[Record](path, statestore.Options[Record]{
-		Version:         StateVersion,
-		Name:            "feishu room state",
-		Equal:           sameRecord,
-		LoadNormalize:   func(record Record) (Record, bool) { return state.NormalizeFeishuRoomStateRecord(record) },
-		LoadKey:         func(record Record) string { return state.FeishuRoomKey(record.RoomID) },
-		LoadEqual:       sameRecord,
-		DefaultVersion:  legacyStateVersion,
-		LegacyVersions:  []int{legacyStateVersion},
+		Version:        StateVersion,
+		Name:           "feishu room state",
+		Equal:          sameRecord,
+		LoadNormalize:  func(record Record) (Record, bool) { return state.NormalizeFeishuRoomStateRecord(record) },
+		LoadKey:        func(record Record) string { return state.FeishuRoomKey(record.RoomID) },
+		LoadEqual:      sameRecord,
+		DefaultVersion: legacyStateVersion,
+		LegacyVersions: []int{legacyStateVersion},
 	})
 	if err != nil {
 		return nil, err

--- a/internal/app/daemon/feishuroomstate/state_test.go
+++ b/internal/app/daemon/feishuroomstate/state_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kxn/codex-remote-feishu/internal/app/daemon/statestore"
 	"github.com/kxn/codex-remote-feishu/internal/core/state"
 )
 
@@ -84,7 +85,7 @@ func TestLoadStoreMigratesPrimaryOnlyVersionOneInPlace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read migrated state: %v", err)
 	}
-	var persisted StateFile
+	var persisted statestore.StateFile[state.FeishuRoomStateRecord]
 	if err := json.Unmarshal(raw, &persisted); err != nil {
 		t.Fatalf("decode migrated state: %v", err)
 	}

--- a/internal/app/daemon/statestore/statestore.go
+++ b/internal/app/daemon/statestore/statestore.go
@@ -23,8 +23,8 @@ import (
 
 // StateFile is the persisted JSON shape shared by all domain state stores.
 type StateFile[T any] struct {
-	Version int            `json:"version"`
-	Entries map[string]T   `json:"entries,omitempty"`
+	Version int          `json:"version"`
+	Entries map[string]T `json:"entries,omitempty"`
 }
 
 // Options carries the per-domain behavior that used to live in each package's

--- a/internal/app/daemon/statestore/statestore.go
+++ b/internal/app/daemon/statestore/statestore.go
@@ -1,0 +1,315 @@
+// Package statestore provides a generic JSON-backed state store used by the
+// daemon's per-domain state packages (bot capability settings, Feishu room
+// state, surface resume, ...).
+//
+// The packages previously each carried their own copy of the same
+// StateFile + Store + Save / replaceEntries / sameEntries template. This
+// package converges that template into a single implementation; each domain
+// package keeps only its record type, key normalization, validation and
+// migration callbacks.
+//
+// The on-disk JSON layout (file name, version field, entries structure) is a
+// persistence contract and must not change. LoadStore must keep accepting the
+// exact same files it accepted before.
+package statestore
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StateFile is the persisted JSON shape shared by all domain state stores.
+type StateFile[T any] struct {
+	Version int            `json:"version"`
+	Entries map[string]T   `json:"entries,omitempty"`
+}
+
+// Options carries the per-domain behavior that used to live in each package's
+// copied template.
+type Options[T any] struct {
+	// Version is the current on-disk version written by Save.
+	Version int
+	// Name is used in version error messages (e.g. "bot capability settings").
+	Name string
+	// Equal compares two records for content equality. It is required for
+	// Replace's change detection. Use reflect-free per-record comparison.
+	Equal func(T, T) bool
+	// Clone deep-copies a record before it is handed out by Entries/Get.
+	// Optional; leave nil to hand out values as-is.
+	Clone func(T) T
+
+	// LoadNormalize normalizes a record while loading; returning ok=false
+	// drops the record and marks the store dirty. Optional.
+	LoadNormalize func(T) (T, bool)
+	// LoadKey derives the canonical key for a normalized record; returning
+	// "" drops the record and marks the store dirty. Optional.
+	LoadKey func(T) string
+	// LoadEqual compares a raw persisted record against its normalized form;
+	// returning false marks the store dirty. Optional.
+	LoadEqual func(T, T) bool
+	// LoadPost post-processes the whole entries map after per-record loading;
+	// returning changed=true marks the store dirty. Optional.
+	LoadPost func(map[string]T) (map[string]T, bool)
+	// DefaultVersion is the version assumed when the file has version 0
+	// (older files written before the version field existed). Defaults to
+	// Version when zero.
+	DefaultVersion int
+	// LegacyVersions lists additional versions that LoadStore accepts and
+	// transparently migrates by rewriting on the next Save.
+	LegacyVersions []int
+	// GetKey normalizes a lookup key in Get. Defaults to strings.TrimSpace.
+	GetKey func(string) string
+}
+
+// Store is a generic JSON-backed entries store with atomic Save semantics.
+type Store[T any] struct {
+	path    string
+	entries map[string]T
+	dirty   bool
+	opts    Options[T]
+}
+
+// StatePath joins stateDir with fileName, mirroring the old per-package
+// StatePath helpers.
+func StatePath(stateDir, fileName string) string {
+	stateDir = strings.TrimSpace(stateDir)
+	if stateDir == "" {
+		return ""
+	}
+	return filepath.Join(stateDir, fileName)
+}
+
+// New creates an empty store bound to path.
+func New[T any](path string, opts Options[T]) *Store[T] {
+	if opts.DefaultVersion == 0 {
+		opts.DefaultVersion = opts.Version
+	}
+	if opts.GetKey == nil {
+		opts.GetKey = strings.TrimSpace
+	}
+	return &Store[T]{
+		path:    strings.TrimSpace(path),
+		entries: map[string]T{},
+		opts:    opts,
+	}
+}
+
+// Path returns the store's file path.
+func (s *Store[T]) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+// Version returns the on-disk version this store writes.
+func (s *Store[T]) Version() int {
+	if s == nil {
+		return 0
+	}
+	return s.opts.Version
+}
+
+// Load reads the store from disk. A missing file yields an empty, clean
+// store. Version mismatches are an error unless the version is listed in
+// LegacyVersions (in which case the store is marked dirty for migration).
+func Load[T any](path string, opts Options[T]) (*Store[T], error) {
+	store := New[T](path, opts)
+	if store.path == "" {
+		return store, nil
+	}
+	raw, err := os.ReadFile(store.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return store, nil
+		}
+		return nil, err
+	}
+	var persisted StateFile[T]
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		return nil, err
+	}
+	version := persisted.Version
+	if version == 0 {
+		version = store.opts.DefaultVersion
+	}
+	if version != store.opts.Version && !containsVersion(store.opts.LegacyVersions, version) {
+		return nil, fmt.Errorf("unsupported %s state version: %d", store.opts.Name, version)
+	}
+	if version != store.opts.Version {
+		store.dirty = true
+	}
+	for key, record := range persisted.Entries {
+		rawRecord := record
+		if store.opts.LoadNormalize != nil {
+			normalized, ok := store.opts.LoadNormalize(record)
+			if !ok {
+				store.dirty = true
+				continue
+			}
+			record = normalized
+		}
+		canonicalKey := store.opts.GetKey(key)
+		if store.opts.LoadKey != nil {
+			canonicalKey = store.opts.LoadKey(record)
+			if canonicalKey == "" {
+				store.dirty = true
+				continue
+			}
+		}
+		if strings.TrimSpace(key) != canonicalKey {
+			store.dirty = true
+		}
+		if store.opts.LoadEqual != nil && !store.opts.LoadEqual(rawRecord, record) {
+			store.dirty = true
+		}
+		store.entries[canonicalKey] = record
+	}
+	if store.opts.LoadPost != nil {
+		if canonical, changed := store.opts.LoadPost(store.entries); changed {
+			store.entries = canonical
+			store.dirty = true
+		}
+	}
+	return store, nil
+}
+
+// SetEntries replaces the in-memory entries without touching the disk. Used
+// by LoadStore implementations with custom parsing.
+func (s *Store[T]) SetEntries(entries map[string]T) {
+	if s == nil {
+		return
+	}
+	s.entries = entries
+}
+
+// MarkDirty flags the store as requiring a rewrite.
+func (s *Store[T]) MarkDirty() {
+	if s == nil {
+		return
+	}
+	s.dirty = true
+}
+
+// Entries returns a copy of the entries map.
+func (s *Store[T]) Entries() map[string]T {
+	if s == nil || len(s.entries) == 0 {
+		return map[string]T{}
+	}
+	values := make(map[string]T, len(s.entries))
+	for key, record := range s.entries {
+		if s.opts.Clone != nil {
+			record = s.opts.Clone(record)
+		}
+		values[key] = record
+	}
+	return values
+}
+
+// Get returns the record stored under key.
+func (s *Store[T]) Get(key string) (T, bool) {
+	var zero T
+	if s == nil {
+		return zero, false
+	}
+	record, ok := s.entries[s.opts.GetKey(key)]
+	if !ok {
+		return zero, false
+	}
+	if s.opts.Clone != nil {
+		record = s.opts.Clone(record)
+	}
+	return record, true
+}
+
+// Replace swaps the entries and persists them, skipping the write when the
+// content is unchanged (mirrors the old replaceEntries semantics).
+func (s *Store[T]) Replace(entries map[string]T) error {
+	if s == nil {
+		return nil
+	}
+	if sameEntries(s.entries, entries, s.opts.Equal) {
+		return nil
+	}
+	previous := s.entries
+	s.entries = entries
+	if err := s.Save(); err != nil {
+		s.entries = previous
+		return err
+	}
+	return nil
+}
+
+// Save atomically writes the entries to disk with the current version.
+func (s *Store[T]) Save() error {
+	if s == nil || s.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+	persisted := StateFile[T]{
+		Version: s.opts.Version,
+		Entries: s.Entries(),
+	}
+	raw, err := json.MarshalIndent(persisted, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+	if err := tmpFile.Chmod(0o600); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if _, err := tmpFile.Write(raw); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return err
+	}
+	s.dirty = false
+	return nil
+}
+
+// Dirty reports whether the store has pending changes that require a rewrite.
+func (s *Store[T]) Dirty() bool {
+	if s == nil {
+		return false
+	}
+	return s.dirty
+}
+
+func sameEntries[T any](left, right map[string]T, equal func(T, T) bool) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, leftRecord := range left {
+		rightRecord, ok := right[key]
+		if !ok || !equal(leftRecord, rightRecord) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsVersion(versions []int, target int) bool {
+	for _, version := range versions {
+		if version == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/daemon/statestore/statestore_test.go
+++ b/internal/app/daemon/statestore/statestore_test.go
@@ -1,0 +1,212 @@
+package statestore
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type testRecord struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func testEqual(left, right testRecord) bool {
+	return left == right
+}
+
+func testKey(record testRecord) string {
+	return record.ID
+}
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := New[testRecord](path, Options[testRecord]{
+		Version: 2,
+		Name:    "test",
+		Equal:   testEqual,
+		LoadKey: testKey,
+	})
+	if store.Dirty() {
+		t.Fatal("new store must be clean")
+	}
+	if err := store.Replace(map[string]testRecord{
+		"a": {ID: "a", Name: "alpha"},
+		"b": {ID: "b", Name: "beta"},
+	}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if store.Dirty() {
+		t.Fatal("store must be clean after save")
+	}
+
+	reloaded, err := Load[testRecord](path, Options[testRecord]{
+		Version: 2,
+		Name:    "test",
+		Equal:   testEqual,
+		LoadKey: testKey,
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if reloaded.Dirty() {
+		t.Fatal("round-trip store must be clean")
+	}
+	got, ok := reloaded.Get("a")
+	if !ok || got.Name != "alpha" {
+		t.Fatalf("get a = %#v, %v", got, ok)
+	}
+	entries := reloaded.Entries()
+	if len(entries) != 2 {
+		t.Fatalf("entries = %#v", entries)
+	}
+}
+
+func TestReplaceSkipsUnchangedWrite(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := New[testRecord](path, Options[testRecord]{
+		Version: 1,
+		Name:    "test",
+		Equal:   testEqual,
+		LoadKey: testKey,
+	})
+	initial := map[string]testRecord{"a": {ID: "a", Name: "alpha"}}
+	if err := store.Replace(initial); err != nil {
+		t.Fatalf("initial replace: %v", err)
+	}
+	statBefore, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if err := store.Replace(initial); err != nil {
+		t.Fatalf("no-op replace: %v", err)
+	}
+	statAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !statBefore.ModTime().Equal(statAfter.ModTime()) {
+		t.Fatal("unchanged replace must not rewrite the file")
+	}
+}
+
+func TestLoadMissingFileIsCleanEmptyStore(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "missing.json")
+	store, err := Load[testRecord](path, Options[testRecord]{
+		Version: 1,
+		Name:    "test",
+		Equal:   testEqual,
+		LoadKey: testKey,
+	})
+	if err != nil {
+		t.Fatalf("load missing: %v", err)
+	}
+	if store.Dirty() {
+		t.Fatal("missing file must yield clean store")
+	}
+	if len(store.Entries()) != 0 {
+		t.Fatalf("entries = %#v", store.Entries())
+	}
+}
+
+func TestLoadRejectsUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	raw := []byte(`{"version":9,"entries":{}}`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load[testRecord](path, Options[testRecord]{
+		Version: 1,
+		Name:    "test",
+		Equal:   testEqual,
+		LoadKey: testKey,
+	}); err == nil {
+		t.Fatal("expected unsupported version error")
+	}
+}
+
+func TestLoadMigratesLegacyVersion(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	raw := []byte(`{"version":1,"entries":{"a":{"id":"a","name":"alpha"}}}`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	store, err := Load[testRecord](path, Options[testRecord]{
+		Version:        2,
+		Name:            "test",
+		Equal:           testEqual,
+		LoadKey:         testKey,
+		LegacyVersions:  []int{1},
+	})
+	if err != nil {
+		t.Fatalf("load legacy: %v", err)
+	}
+	if !store.Dirty() {
+		t.Fatal("legacy version must mark store dirty for rewrite")
+	}
+	if got, ok := store.Get("a"); !ok || got.Name != "alpha" {
+		t.Fatalf("get a = %#v, %v", got, ok)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("save migrated: %v", err)
+	}
+	rawAfter, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after save: %v", err)
+	}
+	var persisted StateFile[testRecord]
+	if err := json.Unmarshal(rawAfter, &persisted); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if persisted.Version != 2 {
+		t.Fatalf("version after migration = %d, want 2", persisted.Version)
+	}
+}
+
+func TestLoadNormalizeDropsInvalidAndMarksDirty(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	raw := []byte(`{"version":1,"entries":{"a":{"id":"a","name":"alpha"},"bad":{"id":"","name":"invalid"}}}`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	store, err := Load[testRecord](path, Options[testRecord]{
+		Version:       1,
+		Name:          "test",
+		Equal:         testEqual,
+		LoadNormalize: func(record testRecord) (testRecord, bool) { return record, record.ID != "" },
+		LoadKey:       testKey,
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !store.Dirty() {
+		t.Fatal("dropped record must mark store dirty")
+	}
+	if len(store.Entries()) != 1 {
+		t.Fatalf("entries = %#v, want only valid record", store.Entries())
+	}
+}
+
+func TestStatePath(t *testing.T) {
+	t.Parallel()
+
+	if got := StatePath("", "x.json"); got != "" {
+		t.Fatalf("StatePath('') = %q, want empty", got)
+	}
+	if got := StatePath("  /tmp/dir  ", "x.json"); got != filepath.Join("/tmp/dir", "x.json") {
+		t.Fatalf("StatePath = %q", got)
+	}
+}

--- a/internal/app/daemon/statestore/statestore_test.go
+++ b/internal/app/daemon/statestore/statestore_test.go
@@ -144,10 +144,10 @@ func TestLoadMigratesLegacyVersion(t *testing.T) {
 	}
 	store, err := Load[testRecord](path, Options[testRecord]{
 		Version:        2,
-		Name:            "test",
-		Equal:           testEqual,
-		LoadKey:         testKey,
-		LegacyVersions:  []int{1},
+		Name:           "test",
+		Equal:          testEqual,
+		LoadKey:        testKey,
+		LegacyVersions: []int{1},
 	})
 	if err != nil {
 		t.Fatalf("load legacy: %v", err)

--- a/internal/app/daemon/surface_resume_state_test.go
+++ b/internal/app/daemon/surface_resume_state_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kxn/codex-remote-feishu/internal/adapter/feishu"
+	"github.com/kxn/codex-remote-feishu/internal/app/daemon/statestore"
 	"github.com/kxn/codex-remote-feishu/internal/app/daemon/surfaceresume"
 	"github.com/kxn/codex-remote-feishu/internal/config"
 	"github.com/kxn/codex-remote-feishu/internal/core/agentproto"
@@ -196,7 +197,7 @@ func TestDaemonStartupCanonicalizesLegacySplitFeishuP2PSurfaceResumeState(t *tes
 	t.Parallel()
 
 	stateDir := t.TempDir()
-	writeSurfaceResumeStateForTest(t, stateDir, surfaceresume.StateFile{
+	writeSurfaceResumeStateForTest(t, stateDir, statestore.StateFile[surfaceresume.Entry]{
 		Version: surfaceresume.StateVersion,
 		Entries: map[string]surfaceresume.Entry{
 			"feishu:Codex-5:user:a756fefe": {
@@ -336,7 +337,7 @@ func TestDaemonDoesNotRestoreCodexPlanModeAcrossRestart(t *testing.T) {
 	t.Parallel()
 
 	stateDir := t.TempDir()
-	writeSurfaceResumeStateForTest(t, stateDir, surfaceresume.StateFile{
+	writeSurfaceResumeStateForTest(t, stateDir, statestore.StateFile[surfaceresume.Entry]{
 		Version: 1,
 		Entries: map[string]surfaceresume.Entry{
 			"surface-1": {
@@ -383,7 +384,7 @@ func TestDaemonDoesNotRestoreClaudePlanModeAcrossRestart(t *testing.T) {
 	t.Parallel()
 
 	stateDir := t.TempDir()
-	writeSurfaceResumeStateForTest(t, stateDir, surfaceresume.StateFile{
+	writeSurfaceResumeStateForTest(t, stateDir, statestore.StateFile[surfaceresume.Entry]{
 		Version: 1,
 		Entries: map[string]surfaceresume.Entry{
 			"surface-1": {
@@ -1950,7 +1951,7 @@ func putSurfaceResumeStateForTest(t *testing.T, stateDir string, entry surfacere
 	}
 }
 
-func writeSurfaceResumeStateForTest(t *testing.T, stateDir string, persisted surfaceresume.StateFile) {
+func writeSurfaceResumeStateForTest(t *testing.T, stateDir string, persisted statestore.StateFile[surfaceresume.Entry]) {
 	t.Helper()
 	path := surfaceresume.StatePath(stateDir)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/app/daemon/surfaceresume/state.go
+++ b/internal/app/daemon/surfaceresume/state.go
@@ -1,13 +1,11 @@
 package surfaceresume
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/kxn/codex-remote-feishu/internal/app/daemon/statestore"
 	"github.com/kxn/codex-remote-feishu/internal/core/agentproto"
 	"github.com/kxn/codex-remote-feishu/internal/core/state"
 	"github.com/kxn/codex-remote-feishu/internal/core/threadtitle"
@@ -43,95 +41,44 @@ type Entry struct {
 	UpdatedAt                   time.Time                `json:"updatedAt,omitempty"`
 }
 
-type StateFile struct {
-	Version int              `json:"version"`
-	Entries map[string]Entry `json:"entries,omitempty"`
-}
-
-type Store struct {
-	path    string
-	entries map[string]Entry
-	dirty   bool
+func StatePath(stateDir string) string {
+	return statestore.StatePath(stateDir, StateFileName)
 }
 
 func NewStore(path string) *Store {
-	return &Store{
-		path:    strings.TrimSpace(path),
-		entries: map[string]Entry{},
-	}
-}
-
-func StatePath(stateDir string) string {
-	stateDir = strings.TrimSpace(stateDir)
-	if stateDir == "" {
-		return ""
-	}
-	return filepath.Join(stateDir, StateFileName)
+	return &Store{Store: statestore.New[Entry](path, statestore.Options[Entry]{
+		Version:       StateVersion,
+		Name:          "surface resume state",
+		Equal:         sameEntryContentIncludingUpdatedAt,
+		LoadNormalize: func(entry Entry) (Entry, bool) { return NormalizeEntry(entry) },
+		LoadKey:       func(entry Entry) string { return entry.SurfaceSessionID },
+		LoadEqual:     SameEntryContent,
+		LoadPost:      CanonicalizeEntries,
+	})}
 }
 
 func LoadStore(path string) (*Store, error) {
-	store := NewStore(path)
-	if store.path == "" {
-		return store, nil
-	}
-	raw, err := os.ReadFile(store.path)
+	store, err := statestore.Load[Entry](path, statestore.Options[Entry]{
+		Version:       StateVersion,
+		Name:          "surface resume state",
+		Equal:         sameEntryContentIncludingUpdatedAt,
+		LoadNormalize: func(entry Entry) (Entry, bool) { return NormalizeEntry(entry) },
+		LoadKey:       func(entry Entry) string { return entry.SurfaceSessionID },
+		LoadEqual:     SameEntryContent,
+		LoadPost:      CanonicalizeEntries,
+	})
 	if err != nil {
-		if os.IsNotExist(err) {
-			return store, nil
-		}
 		return nil, err
 	}
-	var persisted StateFile
-	if err := json.Unmarshal(raw, &persisted); err != nil {
-		return nil, err
-	}
-	if persisted.Version == 0 {
-		persisted.Version = StateVersion
-	}
-	if persisted.Version != StateVersion {
-		return nil, fmt.Errorf("unsupported surface resume state version: %d", persisted.Version)
-	}
-	for key, entry := range persisted.Entries {
-		normalized, ok := NormalizeEntry(entry)
-		if !ok {
-			store.dirty = true
-			continue
-		}
-		if strings.TrimSpace(key) != normalized.SurfaceSessionID {
-			store.dirty = true
-		}
-		if !SameEntryContent(entry, normalized) {
-			store.dirty = true
-		}
-		store.entries[key] = normalized
-	}
-	if canonical, changed := CanonicalizeEntries(store.entries); changed {
-		store.entries = canonical
-		store.dirty = true
-	}
-	return store, nil
+	return &Store{Store: store}, nil
 }
 
-func (s *Store) Entries() map[string]Entry {
-	if s == nil || len(s.entries) == 0 {
-		return map[string]Entry{}
-	}
-	values := make(map[string]Entry, len(s.entries))
-	for key, entry := range s.entries {
-		values[key] = entry
-	}
-	return values
+type Store struct {
+	*statestore.Store[Entry]
 }
 
-func (s *Store) Get(surfaceID string) (Entry, bool) {
-	if s == nil {
-		return Entry{}, false
-	}
-	entry, ok := s.entries[strings.TrimSpace(surfaceID)]
-	if !ok {
-		return Entry{}, false
-	}
-	return entry, true
+func sameEntryContentIncludingUpdatedAt(left, right Entry) bool {
+	return SameEntryContent(left, right) && left.UpdatedAt.Equal(right.UpdatedAt)
 }
 
 func (s *Store) Put(entry Entry) error {
@@ -147,7 +94,7 @@ func (s *Store) Put(entry Entry) error {
 	if canonical, changed := CanonicalizeEntries(entries); changed {
 		entries = canonical
 	}
-	return s.replaceEntries(entries)
+	return s.Replace(entries)
 }
 
 func (s *Store) Delete(surfaceID string) error {
@@ -156,7 +103,7 @@ func (s *Store) Delete(surfaceID string) error {
 	}
 	entries := s.Entries()
 	delete(entries, strings.TrimSpace(surfaceID))
-	return s.replaceEntries(entries)
+	return s.Replace(entries)
 }
 
 func (s *Store) ReplaceAll(entries map[string]Entry) error {
@@ -174,80 +121,7 @@ func (s *Store) ReplaceAll(entries map[string]Entry) error {
 	if canonical, changed := CanonicalizeEntries(normalizedEntries); changed {
 		normalizedEntries = canonical
 	}
-	return s.replaceEntries(normalizedEntries)
-}
-
-func (s *Store) replaceEntries(entries map[string]Entry) error {
-	if sameEntries(s.entries, entries) {
-		return nil
-	}
-	previous := s.entries
-	s.entries = entries
-	if err := s.Save(); err != nil {
-		s.entries = previous
-		return err
-	}
-	return nil
-}
-
-func sameEntries(left, right map[string]Entry) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for key, leftEntry := range left {
-		rightEntry, ok := right[key]
-		if !ok || !SameEntryContent(leftEntry, rightEntry) || !leftEntry.UpdatedAt.Equal(rightEntry.UpdatedAt) {
-			return false
-		}
-	}
-	return true
-}
-
-func (s *Store) Save() error {
-	if s == nil || s.path == "" {
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
-		return err
-	}
-	persisted := StateFile{
-		Version: StateVersion,
-		Entries: s.Entries(),
-	}
-	raw, err := json.MarshalIndent(persisted, "", "  ")
-	if err != nil {
-		return err
-	}
-	raw = append(raw, '\n')
-	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-	if err := tmpFile.Chmod(0o600); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if _, err := tmpFile.Write(raw); err != nil {
-		_ = tmpFile.Close()
-		return err
-	}
-	if err := tmpFile.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, s.path); err != nil {
-		return err
-	}
-	s.dirty = false
-	return nil
-}
-
-func (s *Store) Dirty() bool {
-	if s == nil {
-		return false
-	}
-	return s.dirty
+	return s.Replace(normalizedEntries)
 }
 
 func NormalizeEntry(entry Entry) (Entry, bool) {


### PR DESCRIPTION
## 背景

\internal/app/daemon\ 下 5 个 state 包（botcapabilitysettings / claudeworkspaceprofile / feishubotidentity / feishuroomstate / surfaceresume）是同一模板复制出来的：每包一份 StateFile + Store + StatePath / NewStore / LoadStore / Entries / Get / Put / Delete / Save / Dirty / replaceEntries / sameEntries 样板，合计约 1,900 行。issue #805。

## 改动

- 新增 \internal/app/daemon/statestore\：泛型 \JSONStore[T]\，含原子 Save、Replace（原 replaceEntries/sameEntries 语义）、版本校验/迁移、normalize/key/equal 回调注入、LoadPost 后处理
- 5 个 entries 模板包改为嵌入 \statestore.Store[T]\，只保留 Record 类型、键规范化、校验/迁移回调
- 每包公共 API（StatePath / NewStore / LoadStore / Entries / Get / Put / Delete / ReplaceAll / Save / Dirty）保持不变

## 行为保持

- 磁盘 JSON 格式（StateFile{Version,Entries}、文件名、version 常量）不变——持久化契约
- feishuroomstate legacy v1 迁移 → DefaultVersion + LegacyVersions 选项
- surfaceresume CanonicalizeEntries 后处理 → LoadPost 选项
- claudeworkspaceprofile 的 extraneous-fields 检查保留在自定义 LoadStore（SetEntries/MarkDirty）
- codexoauthstate / profilecontextstate（单 profile / revision 历史 + ETag 的独有逻辑）不迁移

## 验证

- \go build ./...\ 通过
- \go test\ 5 个 state 包 + 新增 statestore 测试全绿
- \go vet\ 通过
- staticcheck U1000：state 包零新增（daemon 主包剩余死代码为基线既有，共 25→15 行）
- daemon 包唯一失败 TestDaemonNormalResumeFailureEmitsNoticeAfterFirstRefresh 已在 origin/master 基线复现（本机环境问题，与本次无关）

净删 567 行模板代码；sameEntries/replaceEntries 单一化到 statestore。Closes #805