### PR TITLE
refactor(config): converge environment variable names to single source

### DIFF
--- a/internal/adapter/feishu/bitable_api.go
+++ b/internal/adapter/feishu/bitable_api.go
@@ -12,7 +12,6 @@ import (
 	larkdrive "github.com/larksuite/oapi-sdk-go/v3/service/drive/v1"
 )
 
-const bitablePermissionDocType = "bitable"
 const bitableBatchRecordLimit = 500
 
 type BitableRecordUpdate struct {

--- a/internal/app/daemon/admin_runtime_requirements.go
+++ b/internal/app/daemon/admin_runtime_requirements.go
@@ -239,7 +239,7 @@ func errorDetail(err error) string {
 }
 
 func resolvedCodexRealBinarySetting(loaded config.LoadedAppConfig) (string, string) {
-	if value := strings.TrimSpace(os.Getenv("CODEX_REAL_BINARY")); value != "" {
+	if value := strings.TrimSpace(os.Getenv(config.CodexRealBinaryEnv)); value != "" {
 		return value, "env_override"
 	}
 	if value := strings.TrimSpace(loaded.Config.Wrapper.CodexRealBinary); value != "" {

--- a/internal/app/daemon/app_upgrade.go
+++ b/internal/app/daemon/app_upgrade.go
@@ -11,6 +11,7 @@ import (
 
 	upgraderuntime "github.com/kxn/codex-remote-feishu/internal/app/daemon/upgraderuntime"
 	"github.com/kxn/codex-remote-feishu/internal/app/install"
+	"github.com/kxn/codex-remote-feishu/internal/config"
 	"github.com/kxn/codex-remote-feishu/internal/core/control"
 	"github.com/kxn/codex-remote-feishu/internal/core/eventcontract"
 	"github.com/kxn/codex-remote-feishu/internal/core/state"
@@ -56,8 +57,8 @@ type upgradeCheckRequest struct {
 
 func (a *App) defaultReleaseLookup(ctx context.Context, track install.ReleaseTrack) (install.ReleaseInfo, error) {
 	return install.ResolveLatestRelease(ctx, install.ReleaseLookupOptions{
-		Repository:     strings.TrimSpace(os.Getenv("CODEX_REMOTE_REPO")),
-		ReleasesAPIURL: strings.TrimSpace(os.Getenv("CODEX_REMOTE_RELEASES_API_URL")),
+		Repository:     strings.TrimSpace(os.Getenv(config.CodexRemoteRepoEnv)),
+		ReleasesAPIURL: strings.TrimSpace(os.Getenv(config.CodexRemoteReleasesAPIURLEnv)),
 		Track:          track,
 	})
 }

--- a/internal/app/daemon/app_upgrade_dev.go
+++ b/internal/app/daemon/app_upgrade_dev.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kxn/codex-remote-feishu/internal/app/install"
+	"github.com/kxn/codex-remote-feishu/internal/config"
 	"github.com/kxn/codex-remote-feishu/internal/core/control"
 	"github.com/kxn/codex-remote-feishu/internal/core/eventcontract"
 	"github.com/kxn/codex-remote-feishu/internal/xutil"
@@ -22,8 +23,8 @@ type devUpgradeCheckRequest struct {
 
 func (a *App) defaultDevManifestLookup(ctx context.Context) (install.DevManifest, install.DevManifestAsset, error) {
 	return install.ResolveDevManifest(ctx, install.DevManifestLookupOptions{
-		Repository:  strings.TrimSpace(os.Getenv("CODEX_REMOTE_REPO")),
-		ManifestURL: strings.TrimSpace(os.Getenv("CODEX_REMOTE_DEV_MANIFEST_URL")),
+		Repository:  strings.TrimSpace(os.Getenv(config.CodexRemoteRepoEnv)),
+		ManifestURL: strings.TrimSpace(os.Getenv(config.CodexRemoteDevManifestURLEnv)),
 	})
 }
 

--- a/internal/app/daemon/app_upgrade_execute.go
+++ b/internal/app/daemon/app_upgrade_execute.go
@@ -12,6 +12,7 @@ import (
 
 	upgraderuntime "github.com/kxn/codex-remote-feishu/internal/app/daemon/upgraderuntime"
 	"github.com/kxn/codex-remote-feishu/internal/app/install"
+	"github.com/kxn/codex-remote-feishu/internal/config"
 	"github.com/kxn/codex-remote-feishu/internal/core/control"
 	"github.com/kxn/codex-remote-feishu/internal/core/eventcontract"
 	relayruntime "github.com/kxn/codex-remote-feishu/internal/runtime"
@@ -73,8 +74,8 @@ func (a *App) runPendingUpgradeStart(request upgradeStartRequest) {
 	switch stateValue.PendingUpgrade.Source {
 	case install.UpgradeSourceRelease:
 		targetBinary, err = install.EnsureReleaseBinary(ctx, install.ReleaseBinaryOptions{
-			Repository:   strings.TrimSpace(os.Getenv("CODEX_REMOTE_REPO")),
-			BaseURL:      strings.TrimSpace(os.Getenv("CODEX_REMOTE_BASE_URL")),
+			Repository:   strings.TrimSpace(os.Getenv(config.CodexRemoteRepoEnv)),
+			BaseURL:      strings.TrimSpace(os.Getenv(config.CodexRemoteBaseURLEnv)),
 			Version:      targetVersion,
 			VersionsRoot: stateValue.VersionsRoot,
 		})

--- a/internal/app/daemon/entry.go
+++ b/internal/app/daemon/entry.go
@@ -96,7 +96,7 @@ func RunMainWithArgs(ctx context.Context, args []string, version, branch string)
 
 	env := envMap(os.Environ())
 	startup := buildStartupAccessPlan(loadedConfig, cfg, identity.BinaryPath, env)
-	envOverrideActive := (strings.TrimSpace(os.Getenv("FEISHU_APP_ID")) != "" || strings.TrimSpace(os.Getenv("FEISHU_APP_SECRET")) != "") &&
+	envOverrideActive := (strings.TrimSpace(os.Getenv(config.FeishuAppIDEnv)) != "" || strings.TrimSpace(os.Getenv(config.FeishuAppSecretEnv)) != "") &&
 		strings.TrimSpace(cfg.FeishuGatewayID) != ""
 
 	app := New(
@@ -296,7 +296,7 @@ func repairInstallStateOnStartup(paths relayruntime.Paths, identity agentproto.S
 }
 
 func resolveDesktopSessionInstanceID() string {
-	if value := strings.TrimSpace(os.Getenv("CODEX_REMOTE_INSTANCE_ID")); value != "" {
+	if value := strings.TrimSpace(os.Getenv(config.CodexRemoteInstanceIDEnv)); value != "" {
 		return value
 	}
 	info, err := install.ResolveCurrentDaemonTargetInfo()

--- a/internal/app/wrapper/app.go
+++ b/internal/app/wrapper/app.go
@@ -98,7 +98,7 @@ func LoadConfig(args []string, version, branch string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	instanceID := strings.TrimSpace(os.Getenv("CODEX_REMOTE_INSTANCE_ID"))
+	instanceID := strings.TrimSpace(os.Getenv(config.CodexRemoteInstanceIDEnv))
 	if instanceID == "" {
 		instanceID, err = generateInstanceID()
 		if err != nil {
@@ -110,10 +110,10 @@ func LoadConfig(args []string, version, branch string) (Config, error) {
 	if displayName == "." || displayName == "/" {
 		displayName = workspaceRoot
 	}
-	if override := strings.TrimSpace(os.Getenv("CODEX_REMOTE_INSTANCE_DISPLAY_NAME")); override != "" {
+	if override := strings.TrimSpace(os.Getenv(config.CodexRemoteInstanceDisplayName)); override != "" {
 		displayName = override
 	}
-	source := strings.TrimSpace(os.Getenv("CODEX_REMOTE_INSTANCE_SOURCE"))
+	source := strings.TrimSpace(os.Getenv(config.CodexRemoteInstanceSourceEnv))
 	if source == "" {
 		source = "vscode"
 	}
@@ -121,8 +121,8 @@ func LoadConfig(args []string, version, branch string) (Config, error) {
 	lifetime, parentPID, err := resolveInstanceLifetime(
 		source,
 		managed,
-		os.Getenv("CODEX_REMOTE_LIFETIME"),
-		os.Getenv("CODEX_REMOTE_PARENT_PID"),
+		os.Getenv(config.CodexRemoteLifetimeEnv),
+		os.Getenv(config.CodexRemoteParentPIDEnv),
 		os.Getppid(),
 	)
 	if err != nil {
@@ -147,7 +147,7 @@ func LoadConfig(args []string, version, branch string) (Config, error) {
 		WorkspaceRoot:         workspaceRoot,
 		WorkspaceKey:          state.ResolveWorkspaceKey(workspaceRoot),
 		ShortName:             shortName,
-		Backend:               agentproto.NormalizeBackend(agentproto.Backend(os.Getenv("CODEX_REMOTE_INSTANCE_BACKEND"))),
+		Backend:               agentproto.NormalizeBackend(agentproto.Backend(os.Getenv(config.CodexRemoteInstanceBackendEnv))),
 		CodexProviderID:       state.NormalizeCodexProviderID(os.Getenv(config.CodexRuntimeProviderIDEnv)),
 		ClaudeProfileID:       state.NormalizeClaudeProfileID(os.Getenv(config.ClaudeRuntimeProfileIDEnv)),
 		ClaudeReasoningEffort: state.NormalizeReasoningEffort(os.Getenv(config.ClaudeEffortLevelEnv)),

--- a/internal/app/wrapper/app_headless_claude.go
+++ b/internal/app/wrapper/app_headless_claude.go
@@ -12,8 +12,6 @@ import (
 	"github.com/kxn/codex-remote-feishu/internal/debuglog"
 )
 
-const relayClaudeBootstrapInitializeID = "relay-bootstrap-initialize"
-
 func (a *App) bootstrapClaude(childStdin io.Writer, childStdout io.Reader, rawLogger *debuglog.RawLogger, reportProblem func(agentproto.ErrorInfo)) (io.Reader, error) {
 	frame, err := a.claudeBootstrapInitializeFrame()
 	if err != nil {
@@ -43,7 +41,7 @@ func (a *App) bootstrapClaude(childStdin io.Writer, childStdout io.Reader, rawLo
 			continue
 		}
 		if readErr == io.EOF {
-			return nil, fmt.Errorf("claude bootstrap: initialize response %q not received before stdout closed", relayClaudeBootstrapInitializeID)
+			return nil, fmt.Errorf("claude bootstrap: initialize response %q not received before stdout closed", relayBootstrapInitializeID)
 		}
 		return nil, readErr
 	}
@@ -52,7 +50,7 @@ func (a *App) bootstrapClaude(childStdin io.Writer, childStdout io.Reader, rawLo
 func (a *App) claudeBootstrapInitializeFrame() ([]byte, error) {
 	bytes, err := json.Marshal(map[string]any{
 		"type":       "control_request",
-		"request_id": relayClaudeBootstrapInitializeID,
+		"request_id": relayBootstrapInitializeID,
 		"request": map[string]any{
 			"subtype": "initialize",
 			"hooks":   map[string]any{},
@@ -73,7 +71,7 @@ func matchClaudeBootstrapInitializeResponse(line []byte) (bool, error) {
 		return false, nil
 	}
 	response, _ := message["response"].(map[string]any)
-	if strings.TrimSpace(lookupStringFromMap(response, "request_id")) != relayClaudeBootstrapInitializeID {
+	if strings.TrimSpace(lookupStringFromMap(response, "request_id")) != relayBootstrapInitializeID {
 		return false, nil
 	}
 	if subtype := strings.TrimSpace(lookupStringFromMap(response, "subtype")); subtype != "success" {

--- a/internal/app/wrapper/codex_binary_resolver.go
+++ b/internal/app/wrapper/codex_binary_resolver.go
@@ -34,7 +34,7 @@ func resolveNormalCodexBinaryWithOptions(configPath, configured string, persist 
 	if configured == "" {
 		return configured, nil
 	}
-	if strings.TrimSpace(os.Getenv("CODEX_REAL_BINARY")) != "" {
+	if strings.TrimSpace(os.Getenv(config.CodexRealBinaryEnv)) != "" {
 		return configured, nil
 	}
 	if looksLikePATHCodexCommand(configured) {

--- a/internal/config/envfile.go
+++ b/internal/config/envfile.go
@@ -43,6 +43,31 @@ const (
 	ExternalAccessProviderEnv     = "CODEX_REMOTE_EXTERNAL_ACCESS_PROVIDER"
 	TryCloudflareBinaryEnv        = "CODEX_REMOTE_TRYCLOUDFLARE_BINARY"
 	TryCloudflareLaunchTimeoutEnv = "CODEX_REMOTE_TRYCLOUDFLARE_LAUNCH_TIMEOUT"
+
+	RelayPortEnv              = "RELAY_PORT"
+	RelayServerURLEnv         = "RELAY_SERVER_URL"
+	RelayHostEnv              = "RELAY_HOST"
+	RelayAPIHostEnv           = "RELAY_API_HOST"
+	RelayAPIPortEnv           = "RELAY_API_PORT"
+	CodexRealBinaryEnv        = "CODEX_REAL_BINARY"
+	WrapperNameModeEnv        = "CODEX_REMOTE_WRAPPER_NAME_MODE"
+	WrapperIntegrationModeEnv = "CODEX_REMOTE_WRAPPER_INTEGRATION_MODE"
+	FeishuGatewayIDEnv        = "FEISHU_GATEWAY_ID"
+	FeishuAppIDEnv            = "FEISHU_APP_ID"
+	FeishuAppSecretEnv        = "FEISHU_APP_SECRET"
+	FeishuUseSystemProxyEnv   = "FEISHU_USE_SYSTEM_PROXY"
+	XDGConfigHomeEnv          = "XDG_CONFIG_HOME"
+
+	CodexRemoteRepoEnv             = "CODEX_REMOTE_REPO"
+	CodexRemoteReleasesAPIURLEnv   = "CODEX_REMOTE_RELEASES_API_URL"
+	CodexRemoteBaseURLEnv          = "CODEX_REMOTE_BASE_URL"
+	CodexRemoteDevManifestURLEnv   = "CODEX_REMOTE_DEV_MANIFEST_URL"
+	CodexRemoteInstanceIDEnv       = "CODEX_REMOTE_INSTANCE_ID"
+	CodexRemoteInstanceDisplayName = "CODEX_REMOTE_INSTANCE_DISPLAY_NAME"
+	CodexRemoteInstanceSourceEnv   = "CODEX_REMOTE_INSTANCE_SOURCE"
+	CodexRemoteLifetimeEnv         = "CODEX_REMOTE_LIFETIME"
+	CodexRemoteParentPIDEnv        = "CODEX_REMOTE_PARENT_PID"
+	CodexRemoteInstanceBackendEnv  = "CODEX_REMOTE_INSTANCE_BACKEND"
 )
 
 func LoadWrapperConfig() (WrapperConfig, error) {
@@ -50,25 +75,25 @@ func LoadWrapperConfig() (WrapperConfig, error) {
 	if err != nil {
 		return WrapperConfig{}, err
 	}
-	relayPort := chooseInt(os.Getenv("RELAY_PORT"), loaded.Config.Relay.ListenPort)
+	relayPort := chooseInt(os.Getenv(RelayPortEnv), loaded.Config.Relay.ListenPort)
 	cfg := WrapperConfig{
 		RelayServerURL: chooseNonEmpty(
-			os.Getenv("RELAY_SERVER_URL"),
+			os.Getenv(RelayServerURLEnv),
 			loaded.Config.Relay.ServerURL,
 			defaultRelayServerURL(relayPort),
 		),
 		CodexRealBinary: chooseNonEmpty(
-			os.Getenv("CODEX_REAL_BINARY"),
+			os.Getenv(CodexRealBinaryEnv),
 			loaded.Config.Wrapper.CodexRealBinary,
 			"codex",
 		),
 		NameMode: chooseNonEmpty(
-			os.Getenv("CODEX_REMOTE_WRAPPER_NAME_MODE"),
+			os.Getenv(WrapperNameModeEnv),
 			loaded.Config.Wrapper.NameMode,
 			"workspace_basename",
 		),
 		IntegrationMode: chooseNonEmpty(
-			os.Getenv("CODEX_REMOTE_WRAPPER_INTEGRATION_MODE"),
+			os.Getenv(WrapperIntegrationModeEnv),
 			loaded.Config.Wrapper.IntegrationMode,
 			"managed_shim",
 		),
@@ -94,24 +119,24 @@ func LoadServicesConfig() (ServicesConfig, error) {
 	}
 	selectedApp := SelectRuntimeFeishuApp(loaded.Config.Feishu.Apps)
 	cfg := ServicesConfig{
-		RelayHost:    chooseNonEmpty(os.Getenv("RELAY_HOST"), loaded.Config.Relay.ListenHost, defaultRelayListenHost),
-		RelayPort:    strconv.Itoa(chooseInt(os.Getenv("RELAY_PORT"), loaded.Config.Relay.ListenPort)),
-		RelayAPIHost: chooseNonEmpty(os.Getenv("RELAY_API_HOST"), loaded.Config.Admin.ListenHost, defaultAdminListenHost),
-		RelayAPIPort: strconv.Itoa(chooseInt(os.Getenv("RELAY_API_PORT"), loaded.Config.Admin.ListenPort)),
+		RelayHost:    chooseNonEmpty(os.Getenv(RelayHostEnv), loaded.Config.Relay.ListenHost, defaultRelayListenHost),
+		RelayPort:    strconv.Itoa(chooseInt(os.Getenv(RelayPortEnv), loaded.Config.Relay.ListenPort)),
+		RelayAPIHost: chooseNonEmpty(os.Getenv(RelayAPIHostEnv), loaded.Config.Admin.ListenHost, defaultAdminListenHost),
+		RelayAPIPort: strconv.Itoa(chooseInt(os.Getenv(RelayAPIPortEnv), loaded.Config.Admin.ListenPort)),
 		FeishuGatewayID: chooseNonEmpty(
-			os.Getenv("FEISHU_GATEWAY_ID"),
+			os.Getenv(FeishuGatewayIDEnv),
 			selectedApp.ID,
 		),
 		FeishuAppID: chooseNonEmpty(
-			os.Getenv("FEISHU_APP_ID"),
+			os.Getenv(FeishuAppIDEnv),
 			selectedApp.AppID,
 		),
 		FeishuAppSecret: chooseNonEmpty(
-			os.Getenv("FEISHU_APP_SECRET"),
+			os.Getenv(FeishuAppSecretEnv),
 			selectedApp.AppSecret,
 		),
 		FeishuUseSystemProxy: chooseBool(
-			os.Getenv("FEISHU_USE_SYSTEM_PROXY"),
+			os.Getenv(FeishuUseSystemProxyEnv),
 			boolString(loaded.Config.Feishu.UseSystemProxy),
 			loaded.Config.Feishu.UseSystemProxy,
 		),
@@ -151,7 +176,7 @@ func ResolveExternalAccessSettings(base ExternalAccessSettings) ExternalAccessSe
 }
 
 func xdgConfigPath(parts ...string) string {
-	base := os.Getenv("XDG_CONFIG_HOME")
+	base := os.Getenv(XDGConfigHomeEnv)
 	if base == "" {
 		home, err := pathscope.UserHomeDir()
 		if err != nil {

--- a/internal/config/envfile_test.go
+++ b/internal/config/envfile_test.go
@@ -17,7 +17,7 @@ func unsetUnifiedConfigOverride(t *testing.T) {
 func TestLoadWrapperConfigRejectsLegacyEnvFiles(t *testing.T) {
 	unsetUnifiedConfigOverride(t)
 	xdgHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdgHome)
+	t.Setenv(XDGConfigHomeEnv, xdgHome)
 
 	legacyPath := filepath.Join(xdgHome, "codex-remote", "config.env")
 	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
@@ -57,7 +57,7 @@ func TestLoadServicesConfigUsesUnifiedConfigEnvOverride(t *testing.T) {
 	unsetUnifiedConfigOverride(t)
 	xdgHome := t.TempDir()
 	overrideDir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdgHome)
+	t.Setenv(XDGConfigHomeEnv, xdgHome)
 
 	overridePath := filepath.Join(overrideDir, "custom.json")
 	cfg := DefaultAppConfig()
@@ -114,10 +114,10 @@ func TestLoadServicesConfigUsesUnifiedConfigEnvOverride(t *testing.T) {
 func TestLoadServicesConfigUsesExplicitFeishuGatewayIDEnvOverride(t *testing.T) {
 	unsetUnifiedConfigOverride(t)
 	xdgHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdgHome)
-	t.Setenv("FEISHU_GATEWAY_ID", "ops")
-	t.Setenv("FEISHU_APP_ID", "cli_env")
-	t.Setenv("FEISHU_APP_SECRET", "secret_env")
+	t.Setenv(XDGConfigHomeEnv, xdgHome)
+	t.Setenv(FeishuGatewayIDEnv, "ops")
+	t.Setenv(FeishuAppIDEnv, "cli_env")
+	t.Setenv(FeishuAppSecretEnv, "secret_env")
 
 	cfg, err := LoadServicesConfig()
 	if err != nil {
@@ -134,9 +134,9 @@ func TestLoadServicesConfigUsesExplicitFeishuGatewayIDEnvOverride(t *testing.T) 
 func TestLoadServicesConfigAllowsHostEnvOverrides(t *testing.T) {
 	unsetUnifiedConfigOverride(t)
 	xdgHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdgHome)
-	t.Setenv("RELAY_HOST", "0.0.0.0")
-	t.Setenv("RELAY_API_HOST", "0.0.0.0")
+	t.Setenv(XDGConfigHomeEnv, xdgHome)
+	t.Setenv(RelayHostEnv, "0.0.0.0")
+	t.Setenv(RelayAPIHostEnv, "0.0.0.0")
 
 	cfg, err := LoadServicesConfig()
 	if err != nil {
@@ -153,7 +153,7 @@ func TestLoadServicesConfigAllowsHostEnvOverrides(t *testing.T) {
 func TestLoadersPreferJSONOverLegacySplitFiles(t *testing.T) {
 	unsetUnifiedConfigOverride(t)
 	xdgHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdgHome)
+	t.Setenv(XDGConfigHomeEnv, xdgHome)
 
 	configPath := filepath.Join(xdgHome, "codex-remote", "config.json")
 	cfg := DefaultAppConfig()
@@ -217,7 +217,7 @@ func TestLoadAppConfigAtPathRejectsLegacyEnvPath(t *testing.T) {
 func TestLoadersRejectLegacySplitFilesWhenJSONMissing(t *testing.T) {
 	unsetUnifiedConfigOverride(t)
 	baseDir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(baseDir, ".config"))
+	t.Setenv(XDGConfigHomeEnv, filepath.Join(baseDir, ".config"))
 
 	configDir := filepath.Join(baseDir, ".config", "codex-remote")
 	wrapperPath := filepath.Join(configDir, "wrapper.env")
@@ -247,7 +247,7 @@ func TestLoadersIgnoreWorkingDirectoryDotEnv(t *testing.T) {
 	unsetUnifiedConfigOverride(t)
 	projectDir := t.TempDir()
 	t.Chdir(projectDir)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), ".config"))
+	t.Setenv(XDGConfigHomeEnv, filepath.Join(t.TempDir(), ".config"))
 
 	dotEnvPath := filepath.Join(projectDir, ".env")
 	if err := os.WriteFile(dotEnvPath, []byte("FEISHU_APP_ID=cli_dotenv\nFEISHU_APP_SECRET=secret_dotenv\n"), 0o600); err != nil {


### PR DESCRIPTION
## 背景

环境变量名没有单一事实来源（issue #806）：`internal/config` 定义了 `*Env` 常量表，但 envfile.go 内又硬编码 13 个 env 字符串；config 包外多个包也直接硬编码 `CODEX_REMOTE_*`、`FEISHU_*`、`RELAY_*` 变量名。改一个变量名要全仓库 grep + 逐个替换。

## 改动

- **config/envfile.go**：补充 13 个缺失的 `*Env` 常量（RELAY_PORT / RELAY_SERVER_URL / RELAY_HOST / RELAY_API_HOST / RELAY_API_PORT / CODEX_REAL_BINARY / CODEX_REMOTE_WRAPPER_NAME_MODE / CODEX_REMOTE_WRAPPER_INTEGRATION_MODE / FEISHU_GATEWAY_ID / FEISHU_APP_ID / FEISHU_APP_SECRET / FEISHU_USE_SYSTEM_PROXY / XDG_CONFIG_HOME），另加 upgrade 与 instance 生命周期变量（CODEX_REMOTE_REPO / RELEASES_API_URL / BASE_URL / DEV_MANIFEST_URL / INSTANCE_ID / DISPLAY_NAME / SOURCE / LIFETIME / PARENT_PID / INSTANCE_BACKEND）
- **跨包收敛**：daemon（app_upgrade / app_upgrade_dev / app_upgrade_execute / entry / admin_runtime_requirements）与 wrapper（app / codex_binary_resolver）全部改用常量
- **测试收敛**：envfile_test.go 的 `t.Setenv` 改用常量
- **同值双常量合并**：删除死常量 `bitablePermissionDocType`（无使用点，与 `cronBitablePermissionDocType` 同值）；wrapper 包 `relayClaudeBootstrapInitializeID` 收敛为共享 `relayBootstrapInitializeID`
- **文档核对**：.env.example 的变量名与常量表完全一致，无需修改

## 行为保持

- 所有常量值与原字面量逐一相同，无行为变更
- 仅允许系统变量（HOME / USERPROFILE 等）保留裸字符串

## 验证

- `go build ./...` 通过
- `go test ./internal/config/...` 通过
- `go vet ./...` 通过
- grep 非 config 包裸 os.Getenv("CODEX_REMOTE_.../FEISHU_.../RELAY_.../CODEX_REAL_...") 归零
- staticcheck U1000：无新增（bitablePermissionDocType 删除后该项消失；feishu 包剩余测试别名是基线既有）

Closes #806
