### PR TITLE
fix: release managed headless writer on detach

### DIFF
--- a/docs/general/remote-surface-state-machine.md
+++ b/docs/general/remote-surface-state-machine.md
@@ -18,7 +18,7 @@
 
 这份文档描述的是**当前代码已经实现**的 remote surface 状态机，不是历史问题列表，也不是未来方案草稿。
 
-2026-08-08 #838 补充：`/detach` 与 `/workspace detach` 都是 detach-like route mutation，会清除当前私聊 surface 的全部 durable resume target（instance、thread、cwd、workspace、route、headless）。清理会在事件/UI/daemon dispatch 之前完成，并在 dispatch 后用同一清理意图再次同步，避免 dispatch 释放 app mutex 时被 recovery tick 插入；`E6 Abandoning` 期间 headless 与 VS Code auto-resume 都明确跳过，直到 surface 最终 detach。
+2026-08-08 #838 补充：`/detach` 与 `/workspace detach` 都是 detach-like route mutation，会清除当前私聊 surface 的全部 durable resume target（instance、thread、cwd、workspace、route、headless）。清理会在事件/UI/daemon dispatch 之前完成，并在 dispatch 后用同一清理意图再次同步，避免 dispatch 释放 app mutex 时被 recovery tick 插入；`E6 Abandoning` 期间 headless 与 VS Code auto-resume 都明确跳过，直到 surface 最终 detach。2026-08-23 #907 补充：surface 最终 detach 后，如果原 attachment 是当前没有其他 surface 使用的 daemon-owned managed headless，orchestrator 会发出定向 `headless.kill`，回收其 Codex app-server writer；这样终端可以立即执行同一 thread 的 `codex resume`，而不会停止其他实例或整个 daemon。active turn 会等收尾，超时强制 detach 也走同一释放路径。
 
 2026-08-08 #840 补充：Feishu 机器人进群事件 `im.chat.member.bot.added_v1` 现在是 room primary bootstrap 的独立入口。daemon 收到事件后先在 app 锁外复用 `feishufacts` scope 缓存确认 `im:chat:readonly`（兼容 `im:chat`），再通过 gateway `im.v1.chat.get` 读取 `chat_mode` 与 `bot_count`；只有 `chat_mode == group` 且 `bot_count == 1` 时才进入锁内尝试写 room primary。锁内写入是 compare-and-set：仅当 `PrimaryGatewayID` 仍为空时把当前 gateway 写入 room durable state 并刷新 primary snapshot；已有 primary 时 no-op，不替换，也不发成功提示。若 room state 持久化失败，daemon 会回滚刚写入的 runtime primary 并刷新 snapshot，不留下只在内存中生效的假 primary。`chat.get` 缺权限会进入现有 permission gap / call broker cooldown 路径，并给群内发送权限提示；事件是否已订阅仍由 setup/admin auto-config 基于已发布版本 `event_infos` 检查，runtime 不把“没有收到事件”推断成未订阅。
 

--- a/internal/app/daemon/app_headless_lifecycle_test.go
+++ b/internal/app/daemon/app_headless_lifecycle_test.go
@@ -338,15 +338,15 @@ func TestDaemonKillInstanceStopsManagedHeadlessProcess(t *testing.T) {
 		ActorUserID:      "user-1",
 	})
 
-	if stoppedPID != 0 {
-		t.Fatalf("expected detach not to stop managed headless pid, got %d", stoppedPID)
+	if stoppedPID != 4321 {
+		t.Fatalf("expected detach to stop managed headless pid 4321, got %d", stoppedPID)
 	}
 	snapshot := app.service.SurfaceSnapshot("surface-1")
 	if snapshot == nil || snapshot.Attachment.InstanceID != "" {
 		t.Fatalf("expected surface to detach after detach, got %#v", snapshot)
 	}
-	if app.service.Instance("inst-headless-1") == nil {
-		t.Fatalf("expected managed headless instance to remain after detach")
+	if app.service.Instance("inst-headless-1") != nil {
+		t.Fatalf("expected detached managed headless instance to be removed")
 	}
 }
 

--- a/internal/core/orchestrator/service_detach_headless.go
+++ b/internal/core/orchestrator/service_detach_headless.go
@@ -1,0 +1,40 @@
+package orchestrator
+
+import (
+	"strings"
+
+	"github.com/kxn/codex-remote-feishu/internal/core/control"
+	"github.com/kxn/codex-remote-feishu/internal/core/eventcontract"
+	"github.com/kxn/codex-remote-feishu/internal/core/state"
+)
+
+// releaseManagedHeadlessAfterDetach releases the daemon-owned app-server that
+// was carrying a detached surface. Keeping that process alive after /detach
+// leaves the Codex thread writer locked and prevents a local `codex resume`
+// from taking over. Do not stop an instance still attached to another surface.
+func (s *Service) releaseManagedHeadlessAfterDetach(surface *state.SurfaceConsoleRecord, instanceID string) []eventcontract.Event {
+	if surface == nil {
+		return nil
+	}
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return nil
+	}
+	inst := s.root.Instances[instanceID]
+	if !state.IsManagedHeadlessInstance(inst) || len(s.findAttachedSurfaces(instanceID)) != 0 {
+		return nil
+	}
+	command := &control.DaemonCommand{
+		Kind:             control.DaemonCommandKillHeadless,
+		SurfaceSessionID: surface.SurfaceSessionID,
+		InstanceID:       instanceID,
+		ThreadID:         surface.SelectedThreadID,
+		ThreadCWD:        inst.WorkspaceRoot,
+		WorkspaceKey:     inst.WorkspaceKey,
+	}
+	return []eventcontract.Event{{
+		Kind:             eventcontract.KindDaemonCommand,
+		SurfaceSessionID: surface.SurfaceSessionID,
+		DaemonCommand:    command,
+	}}
+}

--- a/internal/core/orchestrator/service_detach_headless_test.go
+++ b/internal/core/orchestrator/service_detach_headless_test.go
@@ -1,0 +1,84 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kxn/codex-remote-feishu/internal/core/agentproto"
+	"github.com/kxn/codex-remote-feishu/internal/core/control"
+	"github.com/kxn/codex-remote-feishu/internal/core/state"
+)
+
+func TestDetachDoesNotReleaseManagedHeadlessUsedByAnotherSurface(t *testing.T) {
+	now := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+	svc := newServiceForTest(&now)
+	svc.UpsertInstance(&state.InstanceRecord{
+		InstanceID:    "inst-headless-1",
+		WorkspaceRoot: "/data/dl/droid",
+		WorkspaceKey:  "/data/dl/droid",
+		Source:        "headless",
+		Managed:       true,
+		Online:        true,
+	})
+	first := svc.ensureSurface(control.Action{SurfaceSessionID: "surface-1"})
+	second := svc.ensureSurface(control.Action{SurfaceSessionID: "surface-2"})
+	// The first surface has already finalized its route; the second still owns
+	// the instance, so releasing the managed carrier would be unsafe.
+	first.AttachedInstanceID = ""
+	second.AttachedInstanceID = "inst-headless-1"
+
+	if events := svc.releaseManagedHeadlessAfterDetach(first, "inst-headless-1"); len(events) != 0 {
+		t.Fatalf("expected shared managed headless to remain alive, got %#v", events)
+	}
+}
+
+func TestDetachTimeoutWatchdogForcesFinalizeAfterRunningTurn(t *testing.T) {
+	now := time.Date(2026, 4, 5, 11, 30, 0, 0, time.UTC)
+	svc := newServiceForTest(&now)
+	svc.UpsertInstance(&state.InstanceRecord{
+		InstanceID:              "inst-1",
+		DisplayName:             "droid",
+		WorkspaceRoot:           "/data/dl/droid",
+		WorkspaceKey:            "/data/dl/droid",
+		ShortName:               "droid",
+		Source:                  "headless",
+		Managed:                 true,
+		Online:                  true,
+		ObservedFocusedThreadID: "thread-1",
+		Threads: map[string]*state.ThreadRecord{
+			"thread-1": {ThreadID: "thread-1", Name: "修复登录流程", CWD: "/data/dl/droid"},
+		},
+	})
+	svc.ApplySurfaceAction(control.Action{Kind: control.ActionAttachInstance, SurfaceSessionID: "surface-1", ChatID: "chat-1", ActorUserID: "user-1", InstanceID: "inst-1"})
+	svc.ApplySurfaceAction(control.Action{Kind: control.ActionTextMessage, SurfaceSessionID: "surface-1", MessageID: "msg-1", Text: "你好"})
+	svc.ApplyAgentEvent("inst-1", agentproto.Event{Kind: agentproto.EventTurnStarted, ThreadID: "thread-1", TurnID: "turn-1", Initiator: agentproto.Initiator{Kind: agentproto.InitiatorUnknown}})
+
+	detach := svc.ApplySurfaceAction(control.Action{Kind: control.ActionDetach, SurfaceSessionID: "surface-1"})
+	if len(detach) < 2 {
+		t.Fatalf("expected interrupt + detach_pending flow, got %#v", detach)
+	}
+	if !svc.root.Surfaces["surface-1"].Abandoning {
+		t.Fatalf("expected surface to enter abandoning state")
+	}
+
+	events := svc.Tick(now.Add(21 * time.Second))
+	surface := svc.root.Surfaces["surface-1"]
+	if surface.AttachedInstanceID != "" || surface.Abandoning {
+		t.Fatalf("expected watchdog to force detach, got %#v", surface)
+	}
+	if claim := svc.instanceClaims["inst-1"]; claim != nil {
+		t.Fatalf("expected instance claim to be released, got %#v", claim)
+	}
+	var sawForced, sawKill bool
+	for _, event := range events {
+		if event.Notice != nil && event.Notice.Code == "detach_timeout_forced" {
+			sawForced = true
+		}
+		if event.DaemonCommand != nil && event.DaemonCommand.Kind == control.DaemonCommandKillHeadless && event.DaemonCommand.InstanceID == "inst-1" {
+			sawKill = true
+		}
+	}
+	if !sawForced || !sawKill {
+		t.Fatalf("expected forced detach notice and managed headless release, got %#v", events)
+	}
+}

--- a/internal/core/orchestrator/service_headless_thread_test.go
+++ b/internal/core/orchestrator/service_headless_thread_test.go
@@ -333,68 +333,6 @@ func TestApplyInstanceConnectedClearsPendingHeadlessWithoutThreadTarget(t *testi
 	}
 }
 
-func TestDetachTimeoutWatchdogForcesFinalizeAfterRunningTurn(t *testing.T) {
-	now := time.Date(2026, 4, 5, 11, 30, 0, 0, time.UTC)
-	svc := newServiceForTest(&now)
-	svc.UpsertInstance(&state.InstanceRecord{
-		InstanceID:              "inst-1",
-		DisplayName:             "droid",
-		WorkspaceRoot:           "/data/dl/droid",
-		WorkspaceKey:            "/data/dl/droid",
-		ShortName:               "droid",
-		Online:                  true,
-		ObservedFocusedThreadID: "thread-1",
-		Threads: map[string]*state.ThreadRecord{
-			"thread-1": {ThreadID: "thread-1", Name: "修复登录流程", CWD: "/data/dl/droid"},
-		},
-	})
-	svc.ApplySurfaceAction(control.Action{Kind: control.ActionAttachInstance, SurfaceSessionID: "surface-1", ChatID: "chat-1", ActorUserID: "user-1", InstanceID: "inst-1"})
-	svc.ApplySurfaceAction(control.Action{
-		Kind:             control.ActionTextMessage,
-		SurfaceSessionID: "surface-1",
-		MessageID:        "msg-1",
-		Text:             "你好",
-	})
-	svc.ApplyAgentEvent("inst-1", agentproto.Event{
-		Kind:      agentproto.EventTurnStarted,
-		ThreadID:  "thread-1",
-		TurnID:    "turn-1",
-		Initiator: agentproto.Initiator{Kind: agentproto.InitiatorUnknown},
-	})
-
-	detach := svc.ApplySurfaceAction(control.Action{
-		Kind:             control.ActionDetach,
-		SurfaceSessionID: "surface-1",
-	})
-	if len(detach) < 2 {
-		t.Fatalf("expected interrupt + detach_pending flow, got %#v", detach)
-	}
-	surface := svc.root.Surfaces["surface-1"]
-	if !surface.Abandoning {
-		t.Fatalf("expected surface to enter abandoning state")
-	}
-
-	now = now.Add(21 * time.Second)
-	events := svc.Tick(now)
-
-	surface = svc.root.Surfaces["surface-1"]
-	if surface.AttachedInstanceID != "" || surface.Abandoning {
-		t.Fatalf("expected watchdog to force detach, got %#v", surface)
-	}
-	if claim := svc.instanceClaims["inst-1"]; claim != nil {
-		t.Fatalf("expected instance claim to be released, got %#v", claim)
-	}
-	var sawForced bool
-	for _, event := range events {
-		if event.Notice != nil && event.Notice.Code == "detach_timeout_forced" {
-			sawForced = true
-		}
-	}
-	if !sawForced {
-		t.Fatalf("expected detach_timeout_forced notice, got %#v", events)
-	}
-}
-
 func TestNewThreadReadyDiscardsDraftsAndPreparesCreate(t *testing.T) {
 	now := time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC)
 	svc := newServiceForTest(&now)

--- a/internal/core/orchestrator/service_routing_lifecycle.go
+++ b/internal/core/orchestrator/service_routing_lifecycle.go
@@ -50,7 +50,9 @@ func (s *Service) finishSurfaceAfterWork(surface *state.SurfaceConsoleRecord) []
 	}
 	inst := s.root.Instances[surface.AttachedInstanceID]
 	if surface.Abandoning && !s.surfaceNeedsDelayedDetach(surface, inst) {
+		instanceID := surface.AttachedInstanceID
 		events := s.finalizeDetachedSurface(surface)
+		events = append(events, s.releaseManagedHeadlessAfterDetach(surface, instanceID)...)
 		return append(events, notice(surface, "detached", s.detachedText(surface))...)
 	}
 	if surface.RouteMode == state.RouteModeFollowLocal && !s.surfaceHasLiveRemoteWork(surface) {

--- a/internal/core/orchestrator/service_surface_actions.go
+++ b/internal/core/orchestrator/service_surface_actions.go
@@ -942,7 +942,9 @@ func (s *Service) detach(surface *state.SurfaceConsoleRecord) []eventcontract.Ev
 		if item := surface.QueueItems[surface.ActiveQueueItemID]; item != nil {
 			events = append(events, s.abortSurfaceActiveQueueItemForDetach(surface, item)...)
 		}
+		instanceID := surface.AttachedInstanceID
 		events = append(events, s.finalizeDetachedSurface(surface)...)
+		events = append(events, s.releaseManagedHeadlessAfterDetach(surface, instanceID)...)
 		return append(events, notice(surface, "detached", s.detachedText(surface))...)
 	}
 	if s.surfaceNeedsDelayedDetach(surface, inst) {
@@ -967,7 +969,9 @@ func (s *Service) detach(surface *state.SurfaceConsoleRecord) []eventcontract.Ev
 		}
 		return append(events, notice(surface, "detach_pending", s.detachPendingText(surface))...)
 	}
+	instanceID := surface.AttachedInstanceID
 	events = append(events, s.finalizeDetachedSurface(surface)...)
+	events = append(events, s.releaseManagedHeadlessAfterDetach(surface, instanceID)...)
 	return append(events, notice(surface, "detached", s.detachedText(surface))...)
 }
 

--- a/internal/core/orchestrator/service_tick.go
+++ b/internal/core/orchestrator/service_tick.go
@@ -97,7 +97,9 @@ func (s *Service) Tick(now time.Time) []eventcontract.Event {
 		if surface == nil || !surface.Abandoning {
 			continue
 		}
+		instanceID := surface.AttachedInstanceID
 		events = append(events, s.finalizeDetachedSurface(surface)...)
+		events = append(events, s.releaseManagedHeadlessAfterDetach(surface, instanceID)...)
 		events = append(events, eventcontract.Event{
 			Kind:             eventcontract.KindNotice,
 			SurfaceSessionID: surface.SurfaceSessionID,


### PR DESCRIPTION
## Summary

Fixes #907.

`/detach` currently clears the Feishu surface route but leaves the daemon-owned managed headless `codex app-server` alive. That process keeps the Codex thread writer lock, so a local `codex resume <THREAD_ID>` fails with `already has an active writer` even after Feishu reports that the surface was detached.

## What changed

- Emit a targeted `headless.kill` after immediate detach of a managed headless instance.
- Release the carrier after an active turn finishes or after the existing detach timeout watchdog forces finalization.
- Only release the instance when no other surface is still attached to it.
- Reuse the existing daemon managed-headless kill path, so other instances and the daemon remain online.
- Update the remote surface state-machine documentation.

## Tests

- `go test ./internal/core/orchestrator ./internal/app/daemon`
- `go test ./...`
- `scripts/check/pre-commit.sh`

The full test suite passes. The pre-commit guardrail prints existing repository-wide path warnings but exits successfully with `pre-commit: passed`.

## Reproduction covered

The reported flow is now represented by regression coverage: idle detach releases the managed carrier, delayed/timeout detach releases it after finalization, and a carrier still used by another surface is retained.
