### PR TITLE
fix(wrapper): bound child bootstrap handshake with timeout and parent cancellation

### DIFF
--- a/internal/app/wrapper/app.go
+++ b/internal/app/wrapper/app.go
@@ -29,6 +29,7 @@ const (
 	steerCommandResponseTimeout = 5 * time.Second
 	wrapperChildStopGrace       = 2 * time.Second
 	wrapperChildWaitTimeout     = 5 * time.Second
+	wrapperBootstrapTimeout     = 15 * time.Second
 )
 
 type shutdownRequest struct {

--- a/internal/app/wrapper/app_child_session.go
+++ b/internal/app/wrapper/app_child_session.go
@@ -2,6 +2,7 @@ package wrapper
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os/exec"
 	"sync/atomic"
@@ -49,7 +50,9 @@ func (a *App) launchCodexChildSession(ctx context.Context, rawLogger *debuglog.R
 	}
 	a.debugf("child started: binary=%s pid=%d cwd=%s", a.config.CodexRealBinary, cmd.Process.Pid, a.config.WorkspaceRoot)
 
-	bootstrappedStdout, err := a.bootstrapHeadlessCodex(childStdin, childStdout, rawLogger, reportProblem)
+	bootstrappedStdout, err := a.runChildBootstrap(ctx, wrapperBootstrapTimeout, childCancel, func() (io.Reader, error) {
+		return a.bootstrapHeadlessCodex(childStdin, childStdout, rawLogger, reportProblem)
+	})
 	if err != nil {
 		childCancel()
 		_ = cmd.Wait()
@@ -71,6 +74,37 @@ func (a *App) launchCodexChildSession(ctx context.Context, rawLogger *debuglog.R
 		waitErr:     waitErr,
 		cancel:      childCancel,
 	}, nil
+}
+
+// runChildBootstrap bounds the synthetic initialize handshake. A child that
+// never answers initialize would otherwise block the launch forever, keeping
+// the session process and its whole child tree resident and accumulating under
+// repeated launches (issue #910). On timeout or parent cancellation the child
+// context is cancelled so the process is killed and its stdout pipe closes,
+// which unblocks the bootstrap goroutine and lets it drain into the buffered
+// channel instead of leaking. The caller still owns reaping via cmd.Wait().
+func (a *App) runChildBootstrap(ctx context.Context, timeout time.Duration, childCancel context.CancelFunc, boot func() (io.Reader, error)) (io.Reader, error) {
+	type bootstrapResult struct {
+		stdout io.Reader
+		err    error
+	}
+	done := make(chan bootstrapResult, 1)
+	go func() {
+		stdout, err := boot()
+		done <- bootstrapResult{stdout, err}
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case res := <-done:
+		return res.stdout, res.err
+	case <-ctx.Done():
+		childCancel()
+		return nil, ctx.Err()
+	case <-timer.C:
+		childCancel()
+		return nil, fmt.Errorf("child bootstrap: initialize response not received within %s", timeout)
+	}
 }
 
 func startChildSessionIO(ctx context.Context, session *childSession, parentStdout, parentStderr io.Writer, writeCh chan []byte, runtime backendRuntime, client *relayws.Client, commandResponses *commandResponseTracker, turnTracker *runtimeTurnTracker, activeGeneration *int64, generation int64, errCh chan<- error, debugf func(string, ...any), rawLogger *debuglog.RawLogger, reportProblem func(agentproto.ErrorInfo)) {

--- a/internal/app/wrapper/app_child_session_claude.go
+++ b/internal/app/wrapper/app_child_session_claude.go
@@ -3,6 +3,7 @@ package wrapper
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"strings"
 
@@ -31,7 +32,9 @@ func (a *App) launchClaudeChildSession(ctx context.Context, rawLogger *debuglog.
 	}
 	a.debugf("claude child started: binary=%s pid=%d cwd=%s", claudeBinary, cmd.Process.Pid, a.config.WorkspaceRoot)
 
-	bootstrappedStdout, err := a.bootstrapClaude(childStdin, childStdout, rawLogger, reportProblem)
+	bootstrappedStdout, err := a.runChildBootstrap(ctx, wrapperBootstrapTimeout, childCancel, func() (io.Reader, error) {
+		return a.bootstrapClaude(childStdin, childStdout, rawLogger, reportProblem)
+	})
 	if err != nil {
 		childCancel()
 		_ = cmd.Wait()

--- a/internal/app/wrapper/app_child_session_opencode.go
+++ b/internal/app/wrapper/app_child_session_opencode.go
@@ -46,7 +46,9 @@ func (a *App) launchOpenCodeChildSession(ctx context.Context, rawLogger *debuglo
 	}
 	a.debugf("opencode child started: binary=%s pid=%d cwd=%s", openCodeBinary, cmd.Process.Pid, a.config.WorkspaceRoot)
 
-	bootstrappedStdout, err := a.bootstrapOpenCodeACP(translator, childStdin, childStdout, rawLogger, reportProblem)
+	bootstrappedStdout, err := a.runChildBootstrap(ctx, wrapperBootstrapTimeout, childCancel, func() (io.Reader, error) {
+		return a.bootstrapOpenCodeACP(translator, childStdin, childStdout, rawLogger, reportProblem)
+	})
 	if err != nil {
 		childCancel()
 		_ = cmd.Wait()

--- a/internal/app/wrapper/app_child_session_test.go
+++ b/internal/app/wrapper/app_child_session_test.go
@@ -385,3 +385,71 @@ func TestRestartChildSessionStopsCurrentIOBeforeLaunchingReplacement(t *testing.
 	cancel()
 	waitForSessionIOStopped(next, 2*time.Second)
 }
+
+func TestRunChildBootstrapReturnsBootstrappedStdout(t *testing.T) {
+	app := New(Config{Source: "headless", Version: "test"})
+	stdout, err := app.runChildBootstrap(context.Background(), wrapperBootstrapTimeout, func() {}, func() (io.Reader, error) {
+		return strings.NewReader("bootstrapped"), nil
+	})
+	if err != nil {
+		t.Fatalf("runChildBootstrap: %v", err)
+	}
+	data, err := io.ReadAll(stdout)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if string(data) != "bootstrapped" {
+		t.Fatalf("expected stdout %q, got %q", "bootstrapped", string(data))
+	}
+}
+
+func TestRunChildBootstrapTimesOutWedgedChild(t *testing.T) {
+	pipeReader, pipeWriter := io.Pipe()
+	defer pipeReader.Close()
+	cancelCalled := make(chan struct{})
+	childCancel := func() {
+		// Simulate the kill path: cancelling the child closes its stdout pipe,
+		// which is what unblocks a wedged bootstrap read.
+		_ = pipeWriter.Close()
+		close(cancelCalled)
+	}
+	boot := func() (io.Reader, error) {
+		buf := make([]byte, 1)
+		if _, err := pipeReader.Read(buf); err != nil {
+			return nil, err
+		}
+		return strings.NewReader("unexpected"), nil
+	}
+
+	app := New(Config{Source: "headless", Version: "test"})
+	_, err := app.runChildBootstrap(context.Background(), 20*time.Millisecond, childCancel, boot)
+	if err == nil || !strings.Contains(err.Error(), "not received within") {
+		t.Fatalf("expected bootstrap timeout error, got %v", err)
+	}
+	select {
+	case <-cancelCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child cancel was not invoked on bootstrap timeout")
+	}
+}
+
+func TestRunChildBootstrapHonorsParentCancel(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	ctx, cancelParent := context.WithCancel(context.Background())
+	cancelParent()
+	cancelCalled := make(chan struct{})
+	app := New(Config{Source: "headless", Version: "test"})
+	_, err := app.runChildBootstrap(ctx, wrapperBootstrapTimeout, func() { close(cancelCalled) }, func() (io.Reader, error) {
+		<-block
+		return nil, errors.New("bootstrap should not complete")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	select {
+	case <-cancelCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("child cancel was not invoked on parent cancellation")
+	}
+}


### PR DESCRIPTION
Closes #910

## 问题

三个 backend 的 headless bootstrap(codex/claude/opencode)在 synthetic initialize 握手处都是裸 `ReadBytes`,无 deadline,launch 路径也不响应 ctx 取消。子进程永远不应答时(实测案例:子进程启动链路被文件锁卡死),launch 永久阻塞,会话进程及整棵子进程树滞留;headless pool 持续拉起新实例,进程数无上限堆积,最终顶满 systemd TasksMax(实测 38071),之后该 cgroup 内所有 `clone()` 返回 EAGAIN,daemon 自身 Go runtime `fatal error: newosproc`,故障持续 13 小时直至人工重启。

## 修复

新增 `runChildBootstrap` 统一封装(所有调用点在 `internal/app/wrapper/`):

- 用 `wrapperBootstrapTimeout`(15s,常量与 `wrapperChildWaitTimeout` 同处)约束握手;正常握手 1s 内完成,15s 已很宽裕;
- 握手期间响应父 ctx 取消;
- 超时或取消时 cancel 子进程 ctx——进程被杀、stdout 管道关闭,bootstrap 协程随即解除阻塞并排空到带缓冲 channel,不泄漏;
- `cmd.Wait()` 仍由调用方错误路径负责,行为不变。

三个调用点(codex `app_child_session.go`、claude `app_child_session_claude.go`、opencode `app_child_session_opencode.go`)切换到该封装。

## 测试

- 新增回归测试:
  - `TestRunChildBootstrapReturnsBootstrappedStdout` 正常握手透传;
  - `TestRunChildBootstrapTimesOutWedgedChild` 永不应答的子进程在超时后返回错误且子进程被 cancel;
  - `TestRunChildBootstrapHonorsParentCancel` 父 ctx 取消即时生效并 cancel 子进程;
- `go build ./...`、`go vet`、`gofmt` 通过;`go test ./internal/app/wrapper/` 与 `go test ./...` 全量通过;
- `scripts/check/no-local-paths.sh` 通过。
